### PR TITLE
Closes #106

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -2,10 +2,11 @@ package config
 
 import (
 	"encoding/json"
+	"fmt"
 	"github.com/fitstar/falcore"
 	"github.com/proidiot/gone/errors"
 	"github.com/stretchr/testify/assert"
-	"io"
+	"net"
 	"net/http"
 	"strings"
 	"testing"
@@ -406,127 +407,121 @@ func TestResourceUnmarshalJSON(t *testing.T) {
 	}
 }
 
+type TestHandler struct {}
+
+func (h *TestHandler) UnmarshalJSON([]byte) error {
+	return nil
+}
+
+func (h *TestHandler) ServeHTTP(http.ResponseWriter, *http.Request) {
+	panic(
+		errors.New(
+			"A testHandler can't actually serve HTTP, but an" +
+			" attempt was made to do so.",
+		),
+	)
+}
+
+type TestListener struct {}
+
+func (l *TestListener) UnmarshalJSON([]byte) error {
+	return nil
+}
+
+func (l *TestListener) Accept() (net.Conn, error) {
+	return nil, errors.New(
+		"A testListener can't actually accept connections, but an" +
+		" attempt was made to do so.",
+	)
+}
+
+func (l *TestListener) Close() error {
+	return errors.New(
+		"A testListener can't actually close, but an attempt was" +
+		" made to do so.",
+	)
+}
+
+func (l *TestListener) Addr() net.Addr {
+	return nil
+}
+
 func TestServerFromReader(t *testing.T) {
 	type testStruct struct {
-		validate func(*falcore.Server, error)
-		r io.Reader
+		config string
+		reason string
 	}
 
-	testData := []testStruct {
-		testStruct {
-			func(s *falcore.Server, e error) {
-				assert.Error(
-					t,
-					e,
-					"ServerFromReader should fail when" +
-					" given bad JSON.",
-				)
-				assert.Nil(
-					t,
-					s,
-					"ServerFromReader should not create" +
-					" a server if the config is clearly" +
-					" invalid.",
-				)
-			},
-			strings.NewReader("not json"),
+	RegisterResourceType(
+		"internaltesthandler",
+		func() json.Unmarshaler {
+			return new(TestHandler)
 		},
-		testStruct {
-			func(s *falcore.Server, e error) {
-				assert.Error(
-					t,
-					e,
-					"ServerFromReader should fail when" +
-					" given a null config.",
-				)
-				assert.Nil(
-					t,
-					s,
-					"ServerFromReader should not create" +
-					" a server if the config is null.",
-				)
-			},
-			strings.NewReader("null"),
-		},
-		testStruct {
-			func(s *falcore.Server, e error) {
-				assert.Error(
-					t,
-					e,
-					"ServerFromReader should fail when" +
-					" an empty JSON object (which could" +
-					" reasonably be interpereted as a" +
-					" null value) is given for the" +
-					" config.",
-				)
-				assert.Nil(
-					t,
-					s,
-					"ServerFromReader should not create" +
-					" a server when an empty JSON object" +
-					" (which could reasonably be" +
-					" interpereted as a null value) is" +
-					" given for the config.",
+	)
 
-				)
-			},
-			strings.NewReader("{}"),
+	RegisterResourceType(
+		"internaltestlistener",
+		func() json.Unmarshaler {
+			return new(TestListener)
+		},
+	)
+
+	syntacticallyBad := []testStruct {
+		testStruct {
+			config: `not JSON`,
+			reason: "bad JSON",
 		},
 		testStruct {
-			func(s *falcore.Server, e error) {
-				assert.Error(
-					t,
-					e,
-					"ServerFromReader should fail when" +
-					" a non-Pipeline Resource is" +
-					" specified for a Pipeline.",
-				)
-				assert.Nil(
-					t,
-					s,
-					"ServerFromReader should not create" +
-					" a server when a non-Pipeline" +
-					" Resource is specified for a" +
-					" Pipeline.",
-				)
-			},
-			strings.NewReader(`{
+			config: `null`,
+			reason: "null config",
+		},
+		testStruct {
+			config: `{
+			}`,
+			reason: "empty config",
+		},
+		testStruct {
+			config: `{
 				"resources": {
-					"testResource": {
+					"handler": {
+						"type": "dummyType",
+						"data": null
+					},
+					"listener": {
+						"type": "internaltestlistener",
+						"data": null
+					}
+				},
+				"handler": "handler",
+				"listener": "listener"
+			}`,
+			reason: "invalid handler type",
+		},
+		testStruct {
+			config: `{
+				"resources": {
+					"handler": {
+						"type": "internaltesthandler",
+						"data": null
+					},
+					"listener": {
 						"type": "dummyType",
 						"data": null
 					}
 				},
-				"pipeline": "testResource",
-				"port": 80
-			}`),
+				"handler": "handler",
+				"listener": "listener"
+			}`,
+			reason: "invalid listener type",
 		},
 		testStruct {
-			func(s *falcore.Server, e error) {
-				assert.Error(
-					t,
-					e,
-					"ServerFromReader should fail when" +
-					" a non-filter Resource is" +
-					" specified as an upstream for a" +
-					" Pipeline.",
-				)
-				assert.Nil(
-					t,
-					s,
-					"ServerFromReader should not create" +
-					" a server when a non-filter" +
-					" Resource is specified as an" +
-					" upstream for a Pipeline.",
-				)
-			},
-			strings.NewReader(`{
+			config: `{
 				"resources": {
 					"testResource": {
 						"type": "randomType",
 						"data": null
 					},
-					"pipeline": {
+					"handler": {
 						"type": "pipeline",
 						"data": {
 							"upstream": [{
@@ -534,38 +529,26 @@ func TestServerFromReader(t *testing.T) {
 								"data": "testResource"
 							}]
 						}
+					},
+					"listener": {
+						"type": "internaltestlistener",
+						"data": null
 					}
 				},
-				"pipeline": "pipeline",
-				"port": 80
-			}`),
+				"handler": "handler",
+				"listener": "listener"
+			}`,
+			reason: "non-filter Resource specified as an" +
+			" upstream for a Pipeline",
 		},
 		testStruct {
-			func(s *falcore.Server, e error) {
-				assert.Error(
-					t,
-					e,
-					"ServerFromReader should fail when" +
-					" a non-filter Resource is" +
-					" specified as a downstream for a" +
-					" Pipeline.",
-				)
-				assert.Nil(
-					t,
-					s,
-					"ServerFromReader should not create" +
-					" a server when a non-filter" +
-					" Resource is specified as a" +
-					" downstream for a Pipeline.",
-				)
-			},
-			strings.NewReader(`{
+			config: `{
 				"resources": {
 					"testResource": {
 						"type": "randomType",
 						"data": null
 					},
-					"pipeline": {
+					"handler": {
 						"type": "pipeline",
 						"data": {
 							"downstream": [{
@@ -573,36 +556,26 @@ func TestServerFromReader(t *testing.T) {
 								"data": "testResource"
 							}]
 						}
+					},
+					"listener": {
+						"type": "internaltestlistener",
+						"data": null
 					}
 				},
-				"pipeline": "pipeline",
-				"port": 80
-			}`),
+				"handler": "handler",
+				"listener": "listener"
+			}`,
+			reason: "non-filter Resource specified as a" +
+			" downstream for a Pipeline",
 		},
 		testStruct {
-			func(s *falcore.Server, e error) {
-				assert.Error(
-					t,
-					e,
-					"ServerFromReader should fail when" +
-					" the Pipeline tries to include an" +
-					" undefined Resource.",
-				)
-				assert.Nil(
-					t,
-					s,
-					"ServerFromReader should not create" +
-					" a server when the Pipeline tries" +
-					" to include an undefined Resource.",
-				)
-			},
-			strings.NewReader(`{
+			config: `{
 				"resources": {
 					"testResource2": {
 						"type": "dummyType",
 						"data": null
 					},
-					"pipeline": {
+					"handler": {
 						"type": "pipeline",
 						"data": {
 							"upstream": [{
@@ -610,36 +583,26 @@ func TestServerFromReader(t *testing.T) {
 								"data": "testResource"
 							}]
 						}
+					},
+					"listener": {
+						"type": "internaltestlistener",
+						"data": null
 					}
 				},
-				"pipeline": "pipeline",
-				"port": 80
-			}`),
+				"handler": "handler",
+				"listener": "listener"
+			}`,
+			reason: "non-existant Resource specified as an" +
+			" upstream for a Pipeline",
 		},
 		testStruct {
-			func(s *falcore.Server, e error) {
-				assert.Error(
-					t,
-					e,
-					"ServerFromReader should fail when" +
-					" Resource creation produces an" +
-					" error.",
-				)
-				assert.Nil(
-					t,
-					s,
-					"ServerFromReader should not create" +
-					" a server when Resource creation" +
-					" produces an error.",
-				)
-			},
-			strings.NewReader(`{
+			config: `{
 				"resources": {
 					"testResource": {
 						"type": "dummyType",
 						"data": "error"
 					},
-					"pipeline": {
+					"handler": {
 						"type": "pipeline",
 						"data": {
 							"upstream": [{
@@ -647,34 +610,22 @@ func TestServerFromReader(t *testing.T) {
 								"data": "testResource"
 							}]
 						}
+					},
+					"listener": {
+						"type": "internaltestlistener",
+						"data": null
 					}
 				},
-				"pipeline": "pipeline",
-				"port": 80
-			}`),
+				"handler": "handler",
+				"listener": "listener"
+			}`,
+			reason: "error during Resource creation",
 		},
 		testStruct {
-			func(s *falcore.Server, e error) {
-				assert.Error(
-					t,
-					e,
-					"ServerFromReader should fail when" +
-					" the Pipeline tries to use a" +
-					" Resource of the wrong type.",
-				)
-				assert.Nil(
-					t,
-					s,
-					"ServerFromReader should not create" +
-					" a server when the Pipeline tries" +
-					" to use a Resource of the wrong" +
-					" type.",
-				)
-			},
-			strings.NewReader(`{
+			config: `{
 				"resources": {
-					"testResource": null
-					"pipeline": {
+					"testResource": null,
+					"handler": {
 						"type": "pipeline",
 						"data": {
 							"upstream": [{
@@ -682,35 +633,26 @@ func TestServerFromReader(t *testing.T) {
 								"data": "testResource"
 							}]
 						}
+					},
+					"listener": {
+						"type": "internaltestlistener",
+						"data": null
+					}
 				},
-				"pipeline": "pipeline",
-				"port": 80
-			}`),
+				"handler": "handler",
+				"listener": "listener"
+			}`,
+			reason: "null Resource specified as an upstream for" +
+			" a Pipeline",
 		},
 		testStruct {
-			func(s *falcore.Server, e error) {
-				assert.Error(
-					t,
-					e,
-					"ServerFromReader should fail when" +
-					" a self-referrential Resource is" +
-					" present in the config.",
-				)
-				assert.Nil(
-					t,
-					s,
-					"ServerFromReader should not create" +
-					" a server when a self-referrential" +
-					" Resource is present in the config.",
-				)
-			},
-			strings.NewReader(`{
+			config: `{
 				"resources": {
 					"testResource": {
 						"type": "ref",
 						"data": "testResource"
 					},
-					"pipeline": {
+					"handler": {
 						"type": "pipeline",
 						"data": {
 							"upstream": [{
@@ -718,31 +660,42 @@ func TestServerFromReader(t *testing.T) {
 								"data": "testResource"
 							}]
 						}
+					},
+					"listener": {
+						"type": "internaltestlistener",
+						"data": null
 					}
 				},
-				"pipeline": "pipeline",
-				"port": 80
-			}`),
+				"handler": "handler",
+				"listener": "listener"
+			}`,
+			reason: "self-referential Resource specified as an" +
+			" upstream for a Pipeline",
+		},
+	}
+
+	good := []testStruct{
+		testStruct{
+			config: `{
+				"resources": {
+					"handler": {
+						"type": "internaltesthandler",
+						"data": null
+					},
+					"listener": {
+						"type": "internaltestlistener",
+						"data": null
+					}
+				},
+				"handler": "handler",
+				"listener": "listener"
+			}`,
+			reason: "test resources",
 		},
 		testStruct {
-			func(s *falcore.Server, e error) {
-				assert.NoError(
-					t,
-					e,
-					"ServerFromReader should not fail" +
-					" when given a valid config.",
-				)
-				assert.NotNil(
-					t,
-					s,
-					"ServerFromReader should" +
-					" successfully create a server when" +
-					" given a valid config.",
-				)
-			},
-			strings.NewReader(`{
+			config:`{
 				"resources": {
-					"pipeline": {
+					"handler": {
 						"type": "pipeline",
 						"data": {
 							"upstream": [{
@@ -754,32 +707,29 @@ func TestServerFromReader(t *testing.T) {
 					"testResource": {
 						"type": "dummyType",
 						"data": "foo"
+					},
+					"listener": {
+						"type": "internaltestlistener",
+						"data": null
 					}
 				},
-				"pipeline": "pipeline",
-				"port": 80
-			}`),
+				"handler": "handler",
+				"listener": "listener"
+			}`,
+			reason: "valid config",
 		},
 		testStruct {
-			func(s *falcore.Server, e error) {
-				assert.NoError(
-					t,
-					e,
-					"ServerFromReader should not fail" +
-					" when given a valid config with a" +
-					" reference Resource.",
-				)
-				assert.NotNil(
-					t,
-					s,
-					"ServerFromReader should" +
-					" successfully create a server when" +
-					" given a valid config with a" +
-					" reference Resource.",
-				)
-			},
-			strings.NewReader(`{
+			config:`{
 				"resources": {
+					"handler": {
+						"type": "pipeline",
+						"data": {
+							"upstream": [{
+								"type": "ref",
+								"data": "testResource"
+							}]
+						}
+					},
 					"testResource2": {
 						"type": "dummyType",
 						"data": "foo"
@@ -788,7 +738,20 @@ func TestServerFromReader(t *testing.T) {
 						"type": "ref",
 						"data": "testResource2"
 					},
-					"pipeline": {
+					"listener": {
+						"type": "internaltestlistener",
+						"data": null
+					}
+				},
+				"handler": "handler",
+				"listener": "listener"
+			}`,
+			reason: "double reference",
+		},
+		testStruct {
+			config:`{
+				"resources": {
+					"handler": {
 						"type": "pipeline",
 						"data": {
 							"upstream": [{
@@ -796,103 +759,76 @@ func TestServerFromReader(t *testing.T) {
 								"data": "testResource"
 							}]
 						}
-					}
-				},
-				"pipeline": "pipeline",
-				"port": 80
-			}`),
-		},
-		testStruct {
-			func(s *falcore.Server, e error) {
-				assert.NoError(
-					t,
-					e,
-					"ServerFromReader should not fail" +
-					" when given a valid config with a" +
-					" double reference Resource.",
-				)
-				assert.NotNil(
-					t,
-					s,
-					"ServerFromReader should" +
-					" successfully create a server when" +
-					" given a valid config with a" +
-					" double reference Resource.",
-				)
-			},
-			strings.NewReader(`{
-				"resources": {
-					"testResource3": {
-						"type": "dummyType",
-						"data": "foo"
 					},
-					"testResource2": {
-						"type": "ref",
-						"data": "testResource3"
-					},
-					"testResource": {
-						"type": "ref",
-						"data": "testResource2"
-					},
-					"pipeline": {
-						"type": "pipeline",
-						"data": {
-							"upstream": [{
-								"type": "ref",
-								"data": "testResource"
-							}]
-						}
-					}
-				},
-				"pipeline": "pipeline",
-				"port": 80
-			}`),
-		},
-		testStruct {
-			func(s *falcore.Server, e error) {
-				assert.NoError(
-					t,
-					e,
-					"ServerFromReader should not fail" +
-					" when given a valid config with a" +
-					" Router Resource.",
-				)
-				assert.NotNil(
-					t,
-					s,
-					"ServerFromReader should" +
-					" successfully create a server when" +
-					" given a valid config with a" +
-					" Router Resource.",
-				)
-			},
-			strings.NewReader(`{
-				"resources": {
 					"testResource": {
 						"type": "dummyRouter",
 						"data": null
 					},
-					"pipeline": {
-						"type": "pipeline",
-						"data": {
-							"upstream": [{
-								"type": "ref",
-								"data": "testResource"
-							}]
-						}
+					"listener": {
+						"type": "internaltestlistener",
+						"data": null
 					}
 				},
-				"pipeline": "pipeline",
-				"port": 80
-			}`),
+				"handler": "handler",
+				"listener": "listener"
+			}`,
+			reason: "router in pipeline",
 		},
 	}
 
 	RegisterResourceType("dummyType", newDummy)
 	RegisterResourceType("dummyRouter", newDummyRouter)
 
-	for _, v := range testData {
-		s, e := ServerFromReader(v.r)
-		v.validate(s, e)
+	for _, d := range syntacticallyBad {
+		s, e := ServerFromReader(strings.NewReader(d.config))
+		assert.Nil(
+			t,
+			s,
+			fmt.Sprintf(
+				"ServerFromReader is expected to return a" +
+				" nil config.Server when called with a" +
+				" syntactically bad config, but a non-nil" +
+				" config.Server was returned for such a" +
+				" config: %s",
+				d.reason,
+			),
+		)
+		assert.Error(
+			t,
+			e,
+			fmt.Sprintf(
+				"ServerFromReader is expected to return an" +
+				" error when called with a syntactically bad" +
+				" config, but no error was returned for such" +
+				" a config: %s",
+				d.reason,
+			),
+		)
+	}
+
+	for _, d := range good {
+		s, e := ServerFromReader(strings.NewReader(d.config))
+		assert.NotNil(
+			t,
+			s,
+			fmt.Sprintf(
+				"ServerFromReader is expected to return a" +
+				" non-nil config.Server when called with a" +
+				" good config, but a nil config.Server was" +
+				" returned for such a config: %s",
+				d.reason,
+			),
+		)
+		assert.NoError(
+			t,
+			e,
+			fmt.Sprintf(
+				"ServerFromReader is expected to not return" +
+				" an error when called with a good config," +
+				" but an error was returned for such a" +
+				" config: %s",
+				d.reason,
+			),
+		)
 	}
 }

--- a/config/util/handler.go
+++ b/config/util/handler.go
@@ -1,0 +1,30 @@
+package util
+
+import (
+	"encoding/json"
+	"github.com/stuphlabs/pullcord/config"
+	"net/http"
+)
+
+type TestHandler struct {
+}
+
+func init() {
+	e :=config.RegisterResourceType(
+		"testhandler",
+		func() json.Unmarshaler {
+			return new(TestHandler)
+		},
+	)
+
+	if e != nil {
+		panic(e)
+	}
+}
+
+func (t *TestHandler) UnmarshalJSON([]byte) error {
+	return nil
+}
+
+func (t *TestHandler) ServeHTTP(http.ResponseWriter, *http.Request) {
+}

--- a/config/util/listener.go
+++ b/config/util/listener.go
@@ -1,0 +1,44 @@
+package util
+
+import (
+	"encoding/json"
+	"errors"
+	"github.com/stuphlabs/pullcord/config"
+	"net"
+)
+
+type TestListener struct {
+}
+
+func init() {
+	e := config.RegisterResourceType(
+		"testlistener",
+		func() json.Unmarshaler {
+			return new(TestListener)
+		},
+	)
+
+	if e != nil {
+		panic(e)
+	}
+}
+
+func (t *TestListener) UnmarshalJSON([]byte) error {
+	return nil
+}
+
+func (t *TestListener) Accept() (net.Conn, error) {
+	return nil, errors.New(
+		"TestListener is not intended to be used as a real listener.",
+	)
+}
+
+func (t *TestListener) Close() error {
+	return errors.New(
+		"TestListener is not intended to be used as a real listener.",
+	)
+}
+
+func (t *TestListener) Addr() net.Addr {
+	return nil
+}

--- a/net/basic.go
+++ b/net/basic.go
@@ -1,0 +1,54 @@
+package net
+
+import (
+	"encoding/json"
+	"github.com/stuphlabs/pullcord/config"
+	"net"
+)
+
+type BasicListener struct {
+	Listener net.Listener
+}
+
+func init() {
+	e := config.RegisterResourceType(
+		"basiclistener",
+		func() json.Unmarshaler {
+			return new(BasicListener)
+		},
+	)
+
+	if e != nil {
+		panic(e)
+	}
+}
+
+func (b *BasicListener) UnmarshalJSON(d []byte) error {
+	var t struct {
+		Proto string
+		Laddr string
+	}
+
+	if e := json.Unmarshal(d, &t); e != nil {
+		return e
+	}
+
+	if l, e := net.Listen(t.Proto, t.Laddr); e != nil {
+		return e
+	} else {
+		b.Listener = l
+		return nil
+	}
+}
+
+func (b *BasicListener) Accept() (net.Conn, error) {
+	return b.Listener.Accept()
+}
+
+func (b *BasicListener) Close() error {
+	return b.Listener.Close()
+}
+
+func (b *BasicListener) Addr() net.Addr {
+	return b.Listener.Addr()
+}

--- a/net/basic_test.go
+++ b/net/basic_test.go
@@ -1,0 +1,214 @@
+package net
+
+import (
+	"bytes"
+	"github.com/stretchr/testify/assert"
+	configutil "github.com/stuphlabs/pullcord/config/util"
+	"net"
+	"testing"
+)
+
+func TestBasicListenerType(t *testing.T) {
+	b := new(BasicListener)
+
+	assert.Implements(
+		t,
+		(*net.Listener)(nil),
+		b,
+		"A BasicListener should be a net.Listener, but this" +
+		" BasicListener has the wrong type.",
+	)
+}
+
+func TestBasicListenerConfig(t *testing.T) {
+	test := configutil.ConfigTest{
+		ResourceType: "basiclistener",
+		ListenerTest: true,
+		SyntacticallyBad: []configutil.ConfigTestData{
+			configutil.ConfigTestData{
+				Data: ``,
+				Explanation: "empty config",
+			},
+			configutil.ConfigTestData{
+				Data: `42`,
+				Explanation: "numeric config",
+			},
+			configutil.ConfigTestData{
+				Data: `"test"`,
+				Explanation: "string config",
+			},
+			configutil.ConfigTestData{
+				Data: `{
+				}`,
+				Explanation: "empty object",
+			},
+			configutil.ConfigTestData{
+				Data: `{
+					"proto": "droid",
+					"laddr": ":0"
+				}`,
+				Explanation: "bad protocol",
+			},
+			configutil.ConfigTestData{
+				Data: `{
+					"proto": "tcp",
+					"laddr": "1234 Main St. Podunk, OK 73000"
+				}`,
+				Explanation: "bad address",
+			},
+		},
+		Good: []configutil.ConfigTestData{
+			configutil.ConfigTestData{
+				Data: `{
+					"proto": "tcp",
+					"laddr": ":0"
+				}`,
+				Explanation: "good config",
+			},
+		},
+	}
+
+	test.Run(t)
+}
+
+func TestBasicListenerBehavior(t *testing.T) {
+	nl, e := net.Listen("tcp", ":0")
+	assert.NoError(
+		t,
+		e,
+		"Attempting to create a valid basic listener should not" +
+		" produce an error, but an error was produced.",
+	)
+	assert.NotNil(
+		t,
+		nl,
+		"Attempting to create a valid basic listener should produce" +
+		" a non-nil listener, but a nil listener was produced.",
+	)
+
+	l := &BasicListener{nl}
+
+	if l == nil {
+		return
+	}
+
+	defer func() {
+		e := l.Close()
+		assert.NoError(
+			t,
+			e,
+			"Attempting to close a basic listener should not" +
+			" produce an error, but an error was produced.",
+		)
+	}()
+
+	addr := l.Addr()
+	assert.NotNil(
+		t,
+		addr,
+		"Attempting to get the address from a basic listener should" +
+		" return a non-nil address, but a nil address was returned.",
+	)
+
+	if addr == nil {
+		return
+	}
+
+	expected := "testing"
+
+	done := make(chan interface{})
+	defer func(done <-chan interface{}) {
+		<-done
+	}(done)
+
+	go func(
+		t *testing.T,
+		l *BasicListener,
+		expected string,
+		done chan<- interface{},
+	) {
+		defer func(done chan<- interface{}) {
+			close(done)
+		}(done)
+
+		c, e := l.Accept()
+		assert.NoError(
+			t,
+			e,
+			"Attempting to accept a connection from a valid" +
+			" basic listener should not produce an error, but an" +
+			" error was produced.",
+		)
+		assert.NotNil(
+			t,
+			c,
+			"Attempting to accept a connection from a valid" +
+			" basic listener should produce a non-nil" +
+			" connection, but a nil connection was produced.",
+		)
+		if c == nil {
+			return
+		}
+
+		b := new(bytes.Buffer)
+
+		_, e = b.ReadFrom(c)
+		assert.NoError(
+			t,
+			e,
+			"Attempting to read from an accepted connection that" +
+			" came from a valid basic listener should not" +
+			" produce an error, but an error was produced.",
+		)
+
+		actual := b.String()
+		assert.Equal(
+			t,
+			expected,
+			actual,
+			"Attempting to transmit data through a basic" +
+			" listener should not result in alterred data, but" +
+			" the actual data received was not identical to the" +
+			" data expected to have been sent.",
+		)
+	}(t, l, expected, done)
+
+	c, e := net.Dial(addr.Network(), addr.String())
+	assert.NoError(
+		t,
+		e,
+		"Attempting to connect as a client to a basic listener" +
+		" should not produce an error, but an error was produced.",
+	)
+	assert.NotNil(
+		t,
+		c,
+		"Attempting to connect as a client to a basic listener" +
+		" should produce a non-nil connection, but a nil connection" +
+		" was produced.",
+	)
+
+	if c == nil {
+		return
+	}
+
+	defer func(t *testing.T, c net.Conn) {
+		e := c.Close()
+		assert.NoError(
+			t,
+			e,
+			"Attempting to close a client connection to a basic" +
+			" listener should not produce an error, but an error" +
+			" was produced.",
+		)
+	}(t, c)
+
+	_, e = c.Write([]byte(expected))
+	assert.NoError(
+		t,
+		e,
+		"Attempting to write to a client connection of a basic" +
+		" listener should not produce an error, but an error was" +
+		" produced.",
+	)
+}

--- a/net/doc.go
+++ b/net/doc.go
@@ -1,0 +1,2 @@
+// Package net is a collection of network listeners for use with an HTTP server.
+package net


### PR DESCRIPTION
This PR:
- switches the base config to use an `http.Handler` and a `net.Listener`
- alters the `config/util`-based validator to accommodate the above changes
- adds a basic listener for non-TLS communication