### PR TITLE
Closes #78

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -42,6 +42,16 @@ func RegisterResourceType(
 	return nil
 }
 
+func MustRegisterResourceType(
+	typeName string,
+	newFunc func() json.Unmarshaler,
+) {
+	e := RegisterResourceType(typeName, newFunc)
+	if e != nil {
+		panic(e)
+	}
+}
+
 type Resource struct {
 	Unmarshaled json.Unmarshaler
 	complete bool

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -780,55 +780,63 @@ func TestServerFromReader(t *testing.T) {
 	RegisterResourceType("dummyRouter", newDummyRouter)
 
 	for _, d := range syntacticallyBad {
-		s, e := ServerFromReader(strings.NewReader(d.config))
-		assert.Nil(
-			t,
-			s,
-			fmt.Sprintf(
-				"ServerFromReader is expected to return a" +
-				" nil config.Server when called with a" +
-				" syntactically bad config, but a non-nil" +
-				" config.Server was returned for such a" +
-				" config: %s",
-				d.reason,
-			),
-		)
-		assert.Error(
-			t,
-			e,
-			fmt.Sprintf(
-				"ServerFromReader is expected to return an" +
-				" error when called with a syntactically bad" +
-				" config, but no error was returned for such" +
-				" a config: %s",
-				d.reason,
-			),
-		)
+		d := d
+		t.Run(d.reason, func(t *testing.T) {
+			t.Parallel()
+			s, e := ServerFromReader(strings.NewReader(d.config))
+			assert.Nil(
+				t,
+				s,
+				fmt.Sprintf(
+					"ServerFromReader is expected to return a" +
+					" nil config.Server when called with a" +
+					" syntactically bad config, but a non-nil" +
+					" config.Server was returned for such a" +
+					" config: %s",
+					d.reason,
+				),
+			)
+			assert.Error(
+				t,
+				e,
+				fmt.Sprintf(
+					"ServerFromReader is expected to return an" +
+					" error when called with a syntactically bad" +
+					" config, but no error was returned for such" +
+					" a config: %s",
+					d.reason,
+				),
+			)
+		})
 	}
 
 	for _, d := range good {
-		s, e := ServerFromReader(strings.NewReader(d.config))
-		assert.NotNil(
-			t,
-			s,
-			fmt.Sprintf(
-				"ServerFromReader is expected to return a" +
-				" non-nil config.Server when called with a" +
-				" good config, but a nil config.Server was" +
-				" returned for such a config: %s",
-				d.reason,
-			),
-		)
-		assert.NoError(
-			t,
-			e,
-			fmt.Sprintf(
-				"ServerFromReader is expected to not return" +
-				" an error when called with a good config," +
-				" but an error was returned for such a" +
-				" config: %s",
-				d.reason,
-			),
-		)
+		d := d
+		t.Run(d.reason, func(t *testing.T) {
+			t.Parallel()
+			s, e := ServerFromReader(strings.NewReader(d.config))
+			assert.NotNil(
+				t,
+				s,
+				fmt.Sprintf(
+					"ServerFromReader is expected to return a" +
+					" non-nil config.Server when called with a" +
+					" good config, but a nil config.Server was" +
+					" returned for such a config: %s",
+					d.reason,
+				),
+			)
+			assert.NoError(
+				t,
+				e,
+				fmt.Sprintf(
+					"ServerFromReader is expected to not return" +
+					" an error when called with a good config," +
+					" but an error was returned for such a" +
+					" config: %s",
+					d.reason,
+				),
+			)
+		})
 	}
 }

--- a/net/acme.go
+++ b/net/acme.go
@@ -1,0 +1,52 @@
+package net
+
+import (
+	"golang.org/x/crypto/acme/autocert"
+)
+
+type AcmeConfig struct {
+	AcceptTOS bool
+	Domains []string
+	acmeMgr autocert.Manager
+}
+
+func (a *AcmeConfig) UnmarshalJSON(d []byte) error {
+	var t struct {
+		AcceptTOS bool
+		Domains []string
+	}
+
+	if e := json.Unmarshal(d, &t); e != nil {
+		return e
+	}
+
+	if e := a.assureSetup(); e != nil {
+		return e
+	}
+
+	return nil
+}
+
+func (a *AcmeConfig) assureSetup() error {
+	if !a.AcceptTOS {
+		return errors.New(
+			"The terms of service must be accepted in order to use"+
+				" the default ACME setup.",
+		)
+	}
+
+	a.acmeMgr = autocert.Manager{
+		Prompt: autocert.AcceptTOS,
+		HostPolicy: autocert.HostWhitelist(a.Domains...),
+	}
+
+	return nil
+}
+
+func (a *AcmeConfig) GetCertificate() (Certificate, error) {
+	if e := a.assureSetup(); e != nil {
+		return nil, e
+	}
+
+	return acmeMgr.GetCertificate()
+}

--- a/net/acme.go
+++ b/net/acme.go
@@ -5,8 +5,19 @@ import (
 	"encoding/json"
 	"errors"
 
+	"github.com/stuphlabs/pullcord/config"
+
 	"golang.org/x/crypto/acme/autocert"
 )
+
+func init() {
+	config.MustRegisterResourceType(
+		"acme",
+		func() json.Unmarshaler {
+			return new(AcmeConfig)
+		},
+	)
+}
 
 type AcmeConfig struct {
 	AcceptTOS bool
@@ -23,12 +34,15 @@ func (a *AcmeConfig) UnmarshalJSON(d []byte) error {
 		return e
 	}
 
-	if ! a.AcceptTOS {
+	if ! t.AcceptTOS {
 		return errors.New(
 			"The terms of service must be accepted in order to use"+
 				" the default ACME setup.",
 		)
 	}
+
+	a.AcceptTOS = t.AcceptTOS
+	a.Domains = t.Domains
 
 	return nil
 }

--- a/net/acme.go
+++ b/net/acme.go
@@ -1,13 +1,16 @@
 package net
 
 import (
+	"crypto/tls"
+	"encoding/json"
+	"errors"
+
 	"golang.org/x/crypto/acme/autocert"
 )
 
 type AcmeConfig struct {
 	AcceptTOS bool
 	Domains []string
-	acmeMgr autocert.Manager
 }
 
 func (a *AcmeConfig) UnmarshalJSON(d []byte) error {
@@ -20,33 +23,37 @@ func (a *AcmeConfig) UnmarshalJSON(d []byte) error {
 		return e
 	}
 
-	if e := a.assureSetup(); e != nil {
-		return e
-	}
-
-	return nil
-}
-
-func (a *AcmeConfig) assureSetup() error {
-	if !a.AcceptTOS {
+	if ! a.AcceptTOS {
 		return errors.New(
 			"The terms of service must be accepted in order to use"+
 				" the default ACME setup.",
 		)
 	}
 
-	a.acmeMgr = autocert.Manager{
-		Prompt: autocert.AcceptTOS,
-		HostPolicy: autocert.HostWhitelist(a.Domains...),
-	}
-
 	return nil
 }
 
-func (a *AcmeConfig) GetCertificate() (Certificate, error) {
-	if e := a.assureSetup(); e != nil {
+func (a *AcmeConfig) GetManager() (*autocert.Manager, error) {
+	if ! a.AcceptTOS {
+		return nil, errors.New(
+			"The terms of service must be accepted in order to use"+
+				" the default ACME setup.",
+		)
+	}
+
+	return &autocert.Manager{
+		Prompt: autocert.AcceptTOS,
+		HostPolicy: autocert.HostWhitelist(a.Domains...),
+	}, nil
+}
+
+func (a *AcmeConfig) GetCertificate(
+	hello *tls.ClientHelloInfo,
+) (*tls.Certificate, error) {
+	mgr, e := a.GetManager()
+	if e != nil {
 		return nil, e
 	}
 
-	return acmeMgr.GetCertificate()
+	return mgr.GetCertificate(hello)
 }

--- a/net/acme_test.go
+++ b/net/acme_test.go
@@ -1,0 +1,67 @@
+package net
+
+import (
+	"testing"
+
+	configutil"github.com/stuphlabs/pullcord/config/util"
+)
+
+func TestAcmeConfig(t *testing.T) {
+	test := configutil.ConfigTest{
+		ResourceType: "acme",
+		ListenerTest: true,
+		SyntacticallyBad: []configutil.ConfigTestData{
+			configutil.ConfigTestData{
+				Data: ``,
+				Explanation: "empty config",
+			},
+			configutil.ConfigTestData{
+				Data: `42`,
+				Explanation: "numeric config",
+			},
+			configutil.ConfigTestData{
+				Data: `"test"`,
+				Explanation: "string config",
+			},
+			configutil.ConfigTestData{
+				Data: `{
+				}`,
+				Explanation: "empty object",
+			},
+			configutil.ConfigTestData{
+				Data: `{
+					"accepttos": false
+				}`,
+				Explanation: "unaccepted tos",
+			},
+			configutil.ConfigTestData{
+				Data: `{
+					"accepttos": true,
+					"domains": 7
+				}`,
+				Explanation: "bad domain list",
+			},
+		},
+		Good: []configutil.ConfigTestData{
+			configutil.ConfigTestData{
+				Data: `{
+					"AcceptTOS": true,
+					"domains": [
+						"localhost",
+						"127.0.0.1",
+						"::1"
+					]
+				}`,
+				Explanation: "good config",
+			},
+			configutil.ConfigTestData{
+				Data: `{
+					"accepttos": true
+				}`,
+				Explanation: "missing domains",
+			},
+		},
+	}
+
+	test.Run(t)
+}

--- a/net/basictls.go
+++ b/net/basictls.go
@@ -1,0 +1,85 @@
+package net
+
+import (
+	"bytes"
+	"crypto/tls"
+	"encoding/json"
+	"github.com/stuphlabs/pullcord/config"
+	"net"
+)
+
+type TlsCertificateGetter interface {
+	GetCertificate(*tls.ClientHelloInfo) (*tls.Certificate, error)
+}
+
+type BasicTlsListener struct {
+	Listener net.Listener
+	TlsConfig TlsCertificateGetter
+	actualListener net.Listener
+}
+
+func init() {
+	e := config.RegisterResourceType(
+		"basictlslistener",
+		func() json.Unmarshaler {
+			return new(BasicTlsListener)
+		},
+	)
+
+	if e != nil {
+		panic(e)
+	}
+}
+
+func (b *BasicTlsListener) UnmarshalJSON(d []byte) error {
+	var t struct {
+		Listener config.Resource
+		CertGetter config.Resource
+	}
+
+	dec := json.NewDecoder(bytes.NewReader(d))
+	if e := dec.Decode(&t); e != nil {
+		return e
+	}
+
+	var ok bool
+	b.Listener, ok = t.Listener.Unmarshaled.(net.Listener)
+	if !ok {
+		return config.UnexpectedResourceType
+	}
+
+	b.TlsConfig, ok = t.CertGetter.Unmarshaled.(TlsCertificateGetter)
+	if !ok {
+		return config.UnexpectedResourceType
+	}
+
+	b.assureActualListenerCreated()
+
+	return nil
+}
+
+func (b *BasicTlsListener) assureActualListenerCreated() {
+	if b.actualListener == nil {
+		b.actualListener = tls.NewListener(
+			b.Listener,
+			&tls.Config{
+				GetCertificate: b.TlsConfig.GetCertificate,
+			},
+		)
+	}
+}
+
+func (b *BasicTlsListener) Accept() (net.Conn, error) {
+	b.assureActualListenerCreated()
+	return b.actualListener.Accept()
+}
+
+func (b *BasicTlsListener) Close() error {
+	b.assureActualListenerCreated()
+	return b.actualListener.Close()
+}
+
+func (b *BasicTlsListener) Addr() net.Addr {
+	b.assureActualListenerCreated()
+	return b.actualListener.Addr()
+}

--- a/net/basictls_test.go
+++ b/net/basictls_test.go
@@ -1,0 +1,277 @@
+package net
+
+import (
+	"bytes"
+	"crypto/tls"
+	"crypto/x509"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	configutil "github.com/stuphlabs/pullcord/config/util"
+)
+
+func TestBasicTlsListenerType(t *testing.T) {
+	b := new(BasicTlsListener)
+
+	assert.Implements(
+		t,
+		(*net.Listener)(nil),
+		b,
+		"A BasicTlsListener should be a net.Listener, but this" +
+		" BasicTlsListener has the wrong type.",
+	)
+}
+
+func TestBasicTlsListenerConfig(t *testing.T) {
+	test := configutil.ConfigTest{
+		ResourceType: "basictlslistener",
+		ListenerTest: true,
+		SyntacticallyBad: []configutil.ConfigTestData{
+			configutil.ConfigTestData{
+				Data: ``,
+				Explanation: "empty config",
+			},
+			configutil.ConfigTestData{
+				Data: `42`,
+				Explanation: "numeric config",
+			},
+			configutil.ConfigTestData{
+				Data: `"test"`,
+				Explanation: "string config",
+			},
+			configutil.ConfigTestData{
+				Data: `{
+				}`,
+				Explanation: "empty object",
+			},
+			configutil.ConfigTestData{
+				Data: `{
+					"listener": null,
+					"certgetter": null
+				}`,
+				Explanation: "bad protocol",
+			},
+			configutil.ConfigTestData{
+				Data: `{
+					"listener": {
+						"type": "testcertgetter",
+						"data": null
+					},
+					"certgetter": {
+						"type": "testcertgetter",
+						"data": null
+					}
+				}`,
+				Explanation: "bad listener",
+			},
+			configutil.ConfigTestData{
+				Data: `{
+					"listener": {
+						"type": "testlistener",
+						"data": null
+					},
+					"certgetter": {
+						"type": "testlistener",
+						"data": null
+					}
+				}`,
+				Explanation: "bad certgetter",
+			},
+		},
+		Good: []configutil.ConfigTestData{
+			configutil.ConfigTestData{
+				Data: `{
+					"listener": {
+						"type": "testlistener",
+						"data": null
+					},
+					"certgetter": {
+						"type": "testcertgetter",
+						"data": null
+					}
+				}`,
+				Explanation: "good config",
+			},
+		},
+	}
+
+	test.Run(t)
+}
+
+func TestBasicTlsListenerBehavior(t *testing.T) {
+	nl, e := net.Listen("tcp", "127.0.0.1:0")
+	assert.NoError(
+		t,
+		e,
+		"Attempting to create a valid basic listener should not" +
+		" produce an error, but an error was produced.",
+	)
+	assert.NotNil(
+		t,
+		nl,
+		"Attempting to create a valid basic listener should produce" +
+		" a non-nil listener, but a nil listener was produced.",
+	)
+
+	tlsCert, x509Cert, e := GenSelfSignedLocalhostCertificate(
+		3 * time.Minute,
+	)
+	require.NoError(t, e, "Valid certificates are needed for testing.")
+
+	bel := &BufferedEavesdropListener{
+		Target: nl,
+	}
+
+	l := &BasicTlsListener{
+		Listener: bel,
+		TlsConfig: &TestCertificateGetter{Cert: tlsCert},
+	}
+
+	if l == nil {
+		return
+	}
+
+	defer func() {
+		e := l.Close()
+		assert.NoError(
+			t,
+			e,
+			"Attempting to close a basic listener should not" +
+			" produce an error, but an error was produced.",
+		)
+	}()
+
+	addr := l.Addr()
+	assert.NotNil(
+		t,
+		addr,
+		"Attempting to get the address from a basic listener should" +
+		" return a non-nil address, but a nil address was returned.",
+	)
+
+	if addr == nil {
+		return
+	}
+
+	expected := "testing"
+
+	done := make(chan interface{})
+	defer func(done <-chan interface{}) {
+		<-done
+	}(done)
+
+	go func(
+		t *testing.T,
+		l *BasicTlsListener,
+		bel *BufferedEavesdropListener,
+		expected string,
+		done chan<- interface{},
+	) {
+		defer func(done chan<- interface{}) {
+			close(done)
+		}(done)
+
+		c, e := l.Accept()
+		assert.NoError(
+			t,
+			e,
+			"Attempting to accept a connection from a valid" +
+			" basic listener should not produce an error, but an" +
+			" error was produced.",
+		)
+		assert.NotNil(
+			t,
+			c,
+			"Attempting to accept a connection from a valid" +
+			" basic listener should produce a non-nil" +
+			" connection, but a nil connection was produced.",
+		)
+		if c == nil {
+			return
+		}
+
+		endToEndBuffer := new(bytes.Buffer)
+
+		_, e = endToEndBuffer.ReadFrom(c)
+		assert.NoError(
+			t,
+			e,
+			"Attempting to read from an accepted connection that" +
+			" came from a valid basic listener should not" +
+			" produce an error, but an error was produced.",
+		)
+
+		actualEndToEndMsg := endToEndBuffer.String()
+		assert.Equal(
+			t,
+			expected,
+			actualEndToEndMsg,
+			"Attempting to transmit data through a basic" +
+			" listener should not result in alterred data, but" +
+			" the actual data received was not identical to the" +
+			" data expected to have been sent.",
+		)
+
+		actualTransportMsg := bel.Inbound.String()
+		assert.NotEqual(
+			t,
+			expected,
+			actualTransportMsg,
+			"Transmitting data through a basic TLS listener" +
+				" should not result in the original message" +
+				" being sent in the clear of the raw" +
+				" transport layer.",
+		)
+	}(t, l, bel, expected, done)
+
+	certPool := x509.NewCertPool()
+	certPool.AddCert(x509Cert)
+
+	c, e := tls.Dial(
+		addr.Network(),
+		addr.String(),
+		&tls.Config{
+			RootCAs: certPool,
+		},
+	)
+	assert.NoError(
+		t,
+		e,
+		"Attempting to connect as a client to a basic listener" +
+		" should not produce an error, but an error was produced.",
+	)
+	assert.NotNil(
+		t,
+		c,
+		"Attempting to connect as a client to a basic listener" +
+		" should produce a non-nil connection, but a nil connection" +
+		" was produced.",
+	)
+
+	if c == nil {
+		return
+	}
+
+	defer func(t *testing.T, c net.Conn) {
+		e := c.Close()
+		assert.NoError(
+			t,
+			e,
+			"Attempting to close a client connection to a basic" +
+			" listener should not produce an error, but an error" +
+			" was produced.",
+		)
+	}(t, c)
+
+	_, e = c.Write([]byte(expected))
+	assert.NoError(
+		t,
+		e,
+		"Attempting to write to a client connection of a basic" +
+		" listener should not produce an error, but an error was" +
+		" produced.",
+	)
+}

--- a/net/helper_test.go
+++ b/net/helper_test.go
@@ -1,0 +1,231 @@
+package net
+
+import (
+	"bytes"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/json"
+	"encoding/pem"
+	"io"
+	"math/big"
+	"net"
+	"time"
+
+	"github.com/pkg/errors"
+	"github.com/stuphlabs/pullcord/config"
+)
+
+func init() {
+	e := config.RegisterResourceType(
+		"testcertgetter",
+		func() json.Unmarshaler {
+			return new(TestCertificateGetter)
+		},
+	)
+
+	if e != nil {
+		panic(e)
+	}
+}
+
+type TestCertificateGetter struct{
+	Cert *tls.Certificate
+}
+
+func (t *TestCertificateGetter) UnmarshalJSON([]byte) error {
+	return nil
+}
+
+func (t *TestCertificateGetter) GetCertificate(
+	*tls.ClientHelloInfo,
+) (*tls.Certificate, error) {
+	if t.Cert == nil {
+		return nil, errors.New(
+			"No certificate was added to this" +
+				" TestCertificateGetter",
+		)
+	} else {
+		return t.Cert, nil
+	}
+}
+
+type EavesdroppedConn struct {
+	Target net.Conn
+	Inbound io.Writer
+	Outbound io.Writer
+}
+
+func (ec EavesdroppedConn) Read(b []byte) (int, error) {
+	n, er := ec.Target.Read(b)
+	if n <= 0 {
+		return n, er
+	}
+
+	oer := er
+
+	n, er = ec.Inbound.Write(b[:n])
+
+	if oer != nil {
+		er = oer
+	}
+
+	return n, er
+}
+
+func (ec EavesdroppedConn) Write(b []byte) (int, error) {
+	n, er := ec.Target.Write(b)
+	if n <= 0 {
+		return n, er
+	}
+
+	oer := er
+
+	n, er = ec.Outbound.Write(b[:n])
+
+	if oer != nil {
+		er = oer
+	}
+
+	return n, er
+}
+
+func (ec EavesdroppedConn) Close() error {
+	er := ec.Target.Close()
+
+	if er == nil {
+		if oc, ok := ec.Outbound.(io.Closer); ok {
+			er = oc.Close()
+		}
+	}
+
+	if er == nil {
+		if ic, ok := ec.Inbound.(io.Closer); ok {
+			er = ic.Close()
+		}
+	}
+
+	return er
+}
+
+func (ec EavesdroppedConn) LocalAddr() net.Addr {
+	return ec.Target.LocalAddr()
+}
+
+func (ec EavesdroppedConn) RemoteAddr() net.Addr {
+	return ec.Target.RemoteAddr()
+}
+
+func (ec EavesdroppedConn) SetDeadline(t time.Time) error {
+	return ec.Target.SetDeadline(t)
+}
+
+func (ec EavesdroppedConn) SetReadDeadline(t time.Time) error {
+	return ec.Target.SetReadDeadline(t)
+}
+
+func (ec EavesdroppedConn) SetWriteDeadline(t time.Time) error {
+	return ec.Target.SetWriteDeadline(t)
+}
+
+type BufferedEavesdropListener struct {
+	Target net.Listener
+	Inbound bytes.Buffer
+	Outbound bytes.Buffer
+}
+
+func (bel *BufferedEavesdropListener) Accept() (net.Conn, error) {
+	c, e := bel.Target.Accept()
+
+	ec := EavesdroppedConn{
+		Target: c,
+		Inbound: &bel.Inbound,
+		Outbound: &bel.Outbound,
+	}
+
+	return ec, e
+}
+
+func (bel *BufferedEavesdropListener) Close() error {
+	return bel.Target.Close()
+}
+
+func (bel *BufferedEavesdropListener) Addr() net.Addr {
+	return bel.Target.Addr()
+}
+
+
+func GenSelfSignedLocalhostCertificate(
+	validFor time.Duration,
+) (*tls.Certificate, *x509.Certificate, error) {
+	now := time.Now()
+
+	tpl := &x509.Certificate{
+		DNSNames: []string{"localhost", "localhost.localdomain"},
+		IPAddresses: []net.IP{
+			net.ParseIP("127.0.0.1"),
+			net.ParseIP("::1"),
+		},
+		IsCA: true,
+		NotBefore: now,
+		NotAfter: now.Add(validFor),
+		PublicKeyAlgorithm: x509.RSA,
+		SerialNumber: big.NewInt(1),
+		SignatureAlgorithm: x509.SHA512WithRSA,
+	}
+
+	privKey, e := rsa.GenerateKey(rand.Reader, 1024)
+	if e != nil {
+		return nil, nil, errors.Wrap(
+			e,
+			"Unable to gen RSA key for self-signed cert",
+		)
+	}
+
+	derCert, e := x509.CreateCertificate(
+		rand.Reader,
+		tpl,
+		tpl,
+		&privKey.PublicKey,
+		privKey,
+	)
+	if e != nil {
+		return nil, nil, errors.Wrap(
+			e,
+			"Unable to get raw form of self-signed cert",
+		)
+	}
+
+	pemCert := pem.EncodeToMemory(
+		&pem.Block{
+			Type: "CERTIFICATE",
+			Bytes: derCert,
+		},
+	)
+
+	pemKey := pem.EncodeToMemory(
+		&pem.Block{
+			Type: "RSA PRIVATE KEY",
+			Bytes: x509.MarshalPKCS1PrivateKey(privKey),
+		},
+	)
+
+	x509Cert, e := x509.ParseCertificate(derCert)
+	if e != nil {
+		return nil, nil, errors.Wrap(
+			e,
+			"Unable to get x509 form of self-signed cert",
+		)
+	}
+
+	tlsCert, e := tls.X509KeyPair(pemCert, pemKey)
+	if e != nil {
+		return nil, nil, errors.Wrap(
+			e,
+			"Unable to get tls form of self-signed cert",
+		)
+	}
+
+	return &tlsCert, x509Cert, nil
+}

--- a/net/helper_test.go
+++ b/net/helper_test.go
@@ -8,12 +8,12 @@ import (
 	"crypto/x509"
 	"encoding/json"
 	"encoding/pem"
+	"errors"
 	"io"
 	"math/big"
 	"net"
 	"time"
 
-	"github.com/pkg/errors"
 	"github.com/stuphlabs/pullcord/config"
 )
 
@@ -177,10 +177,7 @@ func GenSelfSignedLocalhostCertificate(
 
 	privKey, e := rsa.GenerateKey(rand.Reader, 1024)
 	if e != nil {
-		return nil, nil, errors.Wrap(
-			e,
-			"Unable to gen RSA key for self-signed cert",
-		)
+		return nil, nil, e
 	}
 
 	derCert, e := x509.CreateCertificate(
@@ -191,10 +188,7 @@ func GenSelfSignedLocalhostCertificate(
 		privKey,
 	)
 	if e != nil {
-		return nil, nil, errors.Wrap(
-			e,
-			"Unable to get raw form of self-signed cert",
-		)
+		return nil, nil, e
 	}
 
 	pemCert := pem.EncodeToMemory(
@@ -213,18 +207,12 @@ func GenSelfSignedLocalhostCertificate(
 
 	x509Cert, e := x509.ParseCertificate(derCert)
 	if e != nil {
-		return nil, nil, errors.Wrap(
-			e,
-			"Unable to get x509 form of self-signed cert",
-		)
+		return nil, nil, e
 	}
 
 	tlsCert, e := tls.X509KeyPair(pemCert, pemKey)
 	if e != nil {
-		return nil, nil, errors.Wrap(
-			e,
-			"Unable to get tls form of self-signed cert",
-		)
+		return nil, nil, e
 	}
 
 	return &tlsCert, x509Cert, nil

--- a/net/pem.go
+++ b/net/pem.go
@@ -1,14 +1,49 @@
 package net
 
 import (
-	"golang.org/x/crypto/acme/autocert"
+	"crypto/tls"
+	"encoding/json"
+
+	"github.com/stuphlabs/pullcord/config"
 )
+
+func init() {
+	e := config.RegisterResourceType(
+		"pem",
+		func() json.Unmarshaler {
+			return new(PemConfig)
+		},
+	)
+
+	if e != nil {
+		panic(e)
+	}
+}
 
 type PemConfig struct {
 	Cert []byte
 	Key []byte
 }
 
-func (p *PemConfig) GetCertificate() (Certificate, error) {
-	return tls.X509KeyPair(a.Cert, a.Key)
+func (p *PemConfig) UnmarshalJSON(d []byte) error {
+	var t struct {
+		Cert string
+		Key string
+	}
+
+	if e := json.Unmarshal(d, &t); e != nil {
+		return e
+	}
+
+	p.Cert = []byte(t.Cert)
+	p.Key = []byte(t.Key)
+
+	return nil
+}
+
+func (p *PemConfig) GetCertificate(
+	*tls.ClientHelloInfo,
+) (*tls.Certificate, error) {
+	c, e := tls.X509KeyPair(p.Cert, p.Key)
+	return &c, e
 }

--- a/net/pem.go
+++ b/net/pem.go
@@ -1,0 +1,14 @@
+package net
+
+import (
+	"golang.org/x/crypto/acme/autocert"
+)
+
+type PemConfig struct {
+	Cert []byte
+	Key []byte
+}
+
+func (p *PemConfig) GetCertificate() (Certificate, error) {
+	return tls.X509KeyPair(a.Cert, a.Key)
+}

--- a/net/pem_test.go
+++ b/net/pem_test.go
@@ -1,0 +1,219 @@
+package net
+
+import (
+	"crypto/tls"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	configutil"github.com/stuphlabs/pullcord/config/util"
+)
+
+// example key and cert stolen from
+// https://github.com/freelan-developers/freelan/tree/d248b/samples/fscp/client
+const exampleKey = `-----BEGIN RSA PRIVATE KEY-----
+MIIJKwIBAAKCAgEA47QNFNFb5Z0BZx66+RxhSlWrnIDHmzXaT/UNJuJFgj5cAPNH
+tNq9s/g7Id5qeL2OV96be0AH03P1pL3ahXSRxubR6G6lIenU9vn/j50JZlrevewE
+/rJP6u6AMOsoO8xKqWF2m1qWdSQc2LVZgdBkWbnwPfS0i5kU9LyiSxzWzBREUV/G
+tjw6+6+y6yzrpWzi4QL9Ojf4vuhvmZLpZG7qRXQvh/qcCMYM6fgannZkUkhnoL5l
+jrEi5wI7mzvqDbuUGYOKp8rYTG5Qu+lpZku76Ih/u5A2DPRQ6JPJmnf569O4of+X
+jmcxzSmzkpoY5NE9aB3ZJQ1fl8t3ClMzbMJ79OikvVmKyMPf97hvdBPcmnrzzgF3
+ePCV7UlvTC5JOELWDDEdhoLIQR6Rnh40V+gzvP0dBoyvs6fyrcthDanbxOEWg0hB
+Qxdj58E4YvFu09B3WdlasuNImB3kH/UhB4E3dSDMkL4+soD2aTs11ZiTMZkpxuTy
+Vb7l6CZC6aAOeJax7sBnrte0FuDTWm/6xThjlfL6elW1k37IioVaOIn8Qw50EIsK
+pmbpWNXnYZj3h+qEumtjzXsvkU1pKHtGQqrSgfbOn0x1edgLt/ByJFLOF1fdgLrg
+iUXTOw+Q0sQNy+46dTfG2a6I1FmST1PX/Fk4qkzIeBOFHACJGReqlFwSw6sCAwEA
+AQKCAgEAs2GLkKPh/oBys3cdGtSFvJbDDBbTqO2C38yQINrOoW1Y85K0IcDVA6uB
+ggwC2r2SHp0K5cyqnaVTlgXO2aXcldIO+Un5Iz9f+3U1JEE1P4JEyV/fC3sTxGNB
+b8hBuOIWy1sxoe96aiwZ4Yr0SXUPKTR3E4fsl7DwNmFIhV3hxYIN1AFcvQG0AcUH
+cYfA2GBwV40QSsX/Wv4ntNdssCdEvZRrQXdnZu4HDGbdKYrhO4U4xgRYY1IeydgT
+dxZ7K3hjkrnzCH6faY7aYT7fPqxZCzZFUlColAoAl0id4Oe1ZlgzssN09MVNEXBR
+vCNTiydfdd9Vyn+/mAi87dBfycVo+inFCO+UOfwH+JFZzPwL3/LW46aVZXHmsLO/
+AWKUrJLObyTtw8Y56n7Bw2bu2Gv2TR+D9cfdfjPYwvNmhtEJ1uxP+RjK0b9/iM66
+pODWgBsxiZu8MqZgwND3Yz+nJXxSnZ9IMMnujcBBnXHqe2WjcK9xXL/IeJ5HbJ6k
+Yn6U7gXbgwABpkTf81EkGfuKonBYAYf6zHi9xFwGpd9OSFUuUCwDAbbmkEjDnKQV
+55l83lvzmftILe0JR9Rxo5CQbcFV0ScKTym0EZakhn2dyMyVuOb5WSSjxiXZbXEq
+fORIYtqZRkD2qHW8O8TKpO8UKrUWPZNLWczAb3Jym2VBj4Z2uIECggEBAPNl2ZQy
+9FO0hXRgIjyOUYwVGToYRjyA9ltYefFoNK9RepKDXi4ul5+96dUjDVKfJLhLER77
+8vUnBcc4QlnTLJBhVFiUjH/UA8HAi/dHJiCWfwNT1v4aS/mbGA4uA6Z08fwl7QFD
+D/N02B+oivELWm5UA3pdj4tKh6Oqy58ne3fZH9grACj1AXnin9U/M4KGjOO6aT5V
+nWrsc+fNQBuzesrwDxlQufdfs0AROyJ9wUkVYgVnSQ/kcEYPT2FvX/JuA2Gm7L9A
+S5YJXEqIfWMuLnoqATLVp/CULU9/fbAR2fIEpFelKsUgRIxXSnolCqsh/L4OMHX0
+TBt4hGQ0X3PjWEECggEBAO9+LQn1FZsYY1bdjM7HKDqBys/TZ3wV3TBEIEBPVrtp
+3OMWuvErfx38seqycHfEQo7THNB7rV+nASI8JqJ28MsMVgejqAwdNHy4rGlSV13o
+LfA5J9YH4Nyt4n7QmQW24o3il4enMGpBMVUcKbb97KmtTm5J+pqQZkQ925hZ6Ge2
+tGbT/j+RH2w1iCTeADMhr5CD+HXCARYcXsfvTGFMxGJ14V+YxoB8dxnulknySrhB
+AkaMi1/wBecCddEal3tcbz8xaj9S/Aj8hrTkDUvopxazykZz1jueP+busn8YZWxL
+oP7ZgYKcfntPVIOnimn9TByBTTugCJcfYK68juwwwOsCggEBAO/EAhzSQQsABoMI
+fFFo5P34frxS00WgyI5dTuq2+0dFHVic3jbiIOz0WRdjiyk7qiF9mSULjl9fDHse
+eYYg14J2zm7gDrOReA3yDi8OQInTltUBTwVLhFIjLQQy4dek1gfMmHcox9rM3GX7
+Urt2sqOCUVbGObQ+O/XHNwTWEPOTyKHaYjL2f3jA/TBFLQnEX5+pryj/j62Xtem/
+sApZuHmXF1iZxEfiVyKilr04YiILVV77SubD4rGxPUI/Q6X+J4iXthoETTFEkUy+
+vb3o7VHcdQfNnr0ISsZIUdkTDL4zQm0wQDylt8ED8FL4kFTaiy3xrl1TxXE+PDS1
+vt3bM8ECggEBAJ0pQOca5R3NSEtVwjRjrzuNtwjg4zUjp+4nlr59Eh6UnvaLEQx4
+jceg7yRkCrgdm8vcMDmEH8b4ch8EOBo/UU79/mqu8/VXKP17tvC6r0iZt6O/7itf
+KinHFi5AN1rvpAaWHvhPN89SjswaWimSwr6qUyC+/Wx2vBWmPjfhMEj3NbWRAnS2
+iFdbXcdLw/fJ8Es2v1KPiGT5Ix2zJH1pgipWzxoLyJ/Cjen/jrJiBLSbPKINUt0X
+RthM3gHloGi8xOhERkPd8jT3enK0gSFCQHv+agwHshuXgrnKBGqxGMWTb8gt9fY/
+OiUzbvOie4uIRG0kUQmCwIBjf+/LH0NRzxcCggEBAJPlKp+nazCac0sHI1KCofKy
+jYQcUNv99Xa2JQKLSYKcNgSlXBROPwJdZsynMR0IFQugk4Rt+tMaJuLiztJqUJqo
+/JS2zIgwnHYqECF1ba4Z+Ikr+6nCyQkWsnGBt0KlXhBPy8K5A+kM8dVehbTnwx+w
+q/odiL1sS+La7o7ocu8SpwQOc558uwYSpDNzl9iEbRsVRvui2+hT3IBUikwLJ0rB
+9meAltEXSgI3UK3lSN1UVKd0j4WS4dA10oQXZVxMTa6X/dJL9kcc9XMwPL6V6++U
+2J45RzLZGDG8q6EIJ0OAEuEEn1mmKTlw3mWThFiOcIPFAic7YBp6H9/1xU3rO4g=
+-----END RSA PRIVATE KEY-----`
+const exampleCert = `-----BEGIN CERTIFICATE-----
+MIIF0DCCA7igAwIBAgIBATANBgkqhkiG9w0BAQUFADB2MQswCQYDVQQGEwJGUjEP
+MA0GA1UECAwGQWxzYWNlMRMwEQYDVQQHDApTdHJhc2JvdXJnMRAwDgYDVQQKDAdG
+cmVlbGFuMQswCQYDVQQDDAJjYTEiMCAGCSqGSIb3DQEJARYTY29udGFjdEBmcmVl
+bGFuLm9yZzAeFw0xMjA1MDUxMjQ3MTFaFw0yMjA1MDMxMjQ3MTFaMGQxCzAJBgNV
+BAYTAkZSMQ8wDQYDVQQIDAZBbHNhY2UxEDAOBgNVBAoMB0ZyZWVsYW4xDjAMBgNV
+BAMMBWFsaWNlMSIwIAYJKoZIhvcNAQkBFhNjb250YWN0QGZyZWVsYW4ub3JnMIIC
+IjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEA47QNFNFb5Z0BZx66+RxhSlWr
+nIDHmzXaT/UNJuJFgj5cAPNHtNq9s/g7Id5qeL2OV96be0AH03P1pL3ahXSRxubR
+6G6lIenU9vn/j50JZlrevewE/rJP6u6AMOsoO8xKqWF2m1qWdSQc2LVZgdBkWbnw
+PfS0i5kU9LyiSxzWzBREUV/Gtjw6+6+y6yzrpWzi4QL9Ojf4vuhvmZLpZG7qRXQv
+h/qcCMYM6fgannZkUkhnoL5ljrEi5wI7mzvqDbuUGYOKp8rYTG5Qu+lpZku76Ih/
+u5A2DPRQ6JPJmnf569O4of+XjmcxzSmzkpoY5NE9aB3ZJQ1fl8t3ClMzbMJ79Oik
+vVmKyMPf97hvdBPcmnrzzgF3ePCV7UlvTC5JOELWDDEdhoLIQR6Rnh40V+gzvP0d
+Boyvs6fyrcthDanbxOEWg0hBQxdj58E4YvFu09B3WdlasuNImB3kH/UhB4E3dSDM
+kL4+soD2aTs11ZiTMZkpxuTyVb7l6CZC6aAOeJax7sBnrte0FuDTWm/6xThjlfL6
+elW1k37IioVaOIn8Qw50EIsKpmbpWNXnYZj3h+qEumtjzXsvkU1pKHtGQqrSgfbO
+n0x1edgLt/ByJFLOF1fdgLrgiUXTOw+Q0sQNy+46dTfG2a6I1FmST1PX/Fk4qkzI
+eBOFHACJGReqlFwSw6sCAwEAAaN7MHkwCQYDVR0TBAIwADAsBglghkgBhvhCAQ0E
+HxYdT3BlblNTTCBHZW5lcmF0ZWQgQ2VydGlmaWNhdGUwHQYDVR0OBBYEFFg1MTTD
+/IfnxNdVLyiphgEsQBxnMB8GA1UdIwQYMBaAFEKcNr3LL/TZXqsrGCSLAS1CwuFH
+MA0GCSqGSIb3DQEBBQUAA4ICAQABWb/1QUiu1uGkL1/VvYvQWdMTkZ8jMOb8AWUw
+RlCnLmrFb5uqZQzhNsXJMKZNDIFdqhXNwJxXmq58a7lF30HUFhezVGLIpVTb3Eqs
+dn4ixW/8Zpy4S8Z1SvKo8ROo5YNpsJJLYp4SDOFfg290jlzIqwy7Prv8VTzXiNXU
+4y7pVFKgFZOwVctvjk9/f9vKvNhvljttgmECVTIwuP/qV9xJSNE+R/GAkkEB25WV
+yFi5slnJ4jcHhM/zvqvtOwPVNmGBMkbLOy0oXqsqEoRj8WUobqxoCkdkrdXjgPv2
+/iT3CHx1H8StYyaSK+j5SkVnqoRDIkQkgjeHyeHm6jngGiEosZT1PV4eECQcxiLH
+zB1MrMk63a/cDsNDOMPTj6y+xSsrMOTY7TxNvjVyQU4Zu6QVXhYh19zEunfvvvG7
+wfacwKv6JZ4TlxVFtb0DP9oRUkRZaSlNpRTKqiNjF+e2OkW0IS9OfoBnnhU0cf3R
+SUbY6R96mqRQnbRgcpdOUvgDVcIzckizXDd5rleen6vD/OB2W+yEFj2+X4rVVbYQ
+mtiMRaeQnHpWbIH2YnQikWKffZlsZGnW0x99+6P1bEp1NdV7tajjxXECFlnOW+cS
+77OBJOhvu4hOMkn8qZY5cHGjVKprS6qm5oBzorAO1iw8TMOYFNAMxCVWuC/67z0b
+1BOqnA==
+-----END CERTIFICATE-----`
+
+func TestPem(t *testing.T) {
+	testCases := map[string]struct{
+		inputCert []byte
+		inputKey []byte
+		inputHello *tls.ClientHelloInfo
+		errorExpected bool
+	} {
+		"nil values": {
+			inputCert: nil,
+			inputKey: nil,
+			inputHello: nil,
+			errorExpected: true,
+		},
+		"example cert": {
+			inputKey: []byte(exampleKey),
+			inputCert: []byte(exampleCert),
+			inputHello: nil,
+			errorExpected: false,
+		},
+	}
+
+	for explanation, test := range testCases {
+		pemConfig := PemConfig{
+			test.inputCert,
+			test.inputKey,
+		}
+		_, actualError := pemConfig.GetCertificate(test.inputHello)
+
+		if test.errorExpected {
+			assert.Errorf(
+				t,
+				actualError,
+				"Expected an error from"+
+					" net.PemConfig.GetCertificate for:"+
+					" %s",
+				explanation,
+			)
+		} else {
+			assert.NoErrorf(
+				t,
+				actualError,
+				"Expected no error from"+
+					" net.PemConfig.GetCertificate for:"+
+					" %s",
+				explanation,
+			)
+		}
+	}
+}
+
+func escnl(s string) string {
+	return strings.Replace(s, "\n", `\n`, -1)
+}
+
+func TestPemConfig(t *testing.T) {
+	test := configutil.ConfigTest{
+		ResourceType: "pem",
+		ListenerTest: true,
+		SyntacticallyBad: []configutil.ConfigTestData{
+			configutil.ConfigTestData{
+				Data: ``,
+				Explanation: "empty config",
+			},
+			configutil.ConfigTestData{
+				Data: `42`,
+				Explanation: "numeric config",
+			},
+			configutil.ConfigTestData{
+				Data: `"test"`,
+				Explanation: "string config",
+			},
+			configutil.ConfigTestData{
+				Data: `{
+					"key": 7,
+					"cert": "`+escnl(exampleCert)+`"
+				}`,
+				Explanation: "bad key",
+			},
+			configutil.ConfigTestData{
+				Data: `{
+					"key": "`+escnl(exampleKey)+`",
+					"cert": {
+						"val": "`+escnl(exampleCert)+`"
+					}
+				}`,
+				Explanation: "bad cert",
+			},
+		},
+		Good: []configutil.ConfigTestData{
+			configutil.ConfigTestData{
+				Data: `{
+				}`,
+				Explanation: "empty object",
+			},
+			configutil.ConfigTestData{
+				Data: `{
+					"key": "`+escnl(exampleKey)+`",
+					"cert": "`+escnl(exampleCert)+`"
+				}`,
+				Explanation: "good config",
+			},
+			configutil.ConfigTestData{
+				Data: `{
+					"key": "`+escnl(exampleKey)+`"
+				}`,
+				Explanation: "missing cert",
+			},
+			configutil.ConfigTestData{
+				Data: `{
+					"cert": "`+escnl(exampleCert)+`"
+				}`,
+				Explanation: "missing key",
+			},
+		},
+	}
+
+	test.Run(t)
+}
+
+


### PR DESCRIPTION
Adds a basic TLS listener along with mechanisms for getting TLS certificates either from the config (via PEM-encoded certificate/key bundles) or from Let's Encrypt.