### PR TITLE
Closes #136

### DIFF
--- a/net/basictls_test.go
+++ b/net/basictls_test.go
@@ -126,8 +126,8 @@ func TestBasicTlsListenerBehavior(t *testing.T) {
 	}
 
 	l := &BasicTlsListener{
-		Listener:  bel,
-		TlsConfig: &TestCertificateGetter{Cert: tlsCert},
+		Listener:   bel,
+		CertGetter: &TestCertificateGetter{Cert: tlsCert},
 	}
 
 	if l == nil {


### PR DESCRIPTION
Synchronize the naming scheme of the basic TLS CertGetter. 