### PR TITLE
Closes #147 - Adds missing doc blocks for exported symbols

### DIFF
--- a/authentication/cookiemask.go
+++ b/authentication/cookiemask.go
@@ -51,6 +51,7 @@ func init() {
 	)
 }
 
+// UnmarshalJSON implements encoding/json.Unmarshaler.
 func (f *CookiemaskFilter) UnmarshalJSON(input []byte) error {
 	var t struct {
 		Handler config.Resource

--- a/authentication/doc.go
+++ b/authentication/doc.go
@@ -1,2 +1,2 @@
-// Authetnication-related code for Pullcord
+// Package authentication has mechanisms for authenticating users to Pullcord
 package authentication

--- a/authentication/inmempwdstore.go
+++ b/authentication/inmempwdstore.go
@@ -90,6 +90,7 @@ type Pbkdf2Hash struct {
 	Iterations uint16
 }
 
+// UnmarshalJSON implements encoding/json.Unmarshaler.
 func (hashStruct *Pbkdf2Hash) UnmarshalJSON(input []byte) error {
 	var t struct {
 		Hash       string
@@ -118,6 +119,7 @@ func (hashStruct *Pbkdf2Hash) UnmarshalJSON(input []byte) error {
 	}
 }
 
+// MarshalJSON implements encoding/json.Marshaler.
 func (hashStruct *Pbkdf2Hash) MarshalJSON() ([]byte, error) {
 	var t struct {
 		Hash       string
@@ -169,6 +171,9 @@ func GetPbkdf2Hash(
 	return &hashStruct, nil
 }
 
+// Check verifies that the given password yields the same PBKDF2 hash given the
+// same salt and iteration count. It returns nil if the resulting hash matches,
+// or an error if the resulting hash does not match.
 func (hashStruct *Pbkdf2Hash) Check(
 	password string,
 ) error {
@@ -197,6 +202,7 @@ func (store *InMemPwdStore) CheckPassword(id, pass string) error {
 	}
 }
 
+// UnmarshalJSON implements encoding/json.Unmarshaler.
 func (store *InMemPwdStore) UnmarshalJSON(input []byte) error {
 	return json.Unmarshal(input, (*map[string]*Pbkdf2Hash)(store))
 }

--- a/authentication/inmempwdstore.go
+++ b/authentication/inmempwdstore.go
@@ -138,8 +138,8 @@ func (hashStruct *Pbkdf2Hash) MarshalJSON() ([]byte, error) {
 // testing. All passwords are hashed using PBKDF2 with SHA-256.
 type InMemPwdStore map[string]*Pbkdf2Hash
 
-// SetPassword is a function that allows a password to be hashed and added to
-// an InMemPwdStore instance.
+// GetPbkdf2Hash generates a new PBKDF2 hash in a secure way from a raw
+// password and an iteration count.
 func GetPbkdf2Hash(
 	password string,
 	iterations uint16,

--- a/authentication/login_handler.go
+++ b/authentication/login_handler.go
@@ -40,6 +40,7 @@ func init() {
 	)
 }
 
+// UnmarshalJSON implements encoding/json.Unmarshaler.
 func (h *LoginHandler) UnmarshalJSON(input []byte) error {
 	var t struct {
 		Identifier      string

--- a/authentication/login_handler.go
+++ b/authentication/login_handler.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stuphlabs/pullcord/util"
 )
 
+// XsrfTokenLength is the length of XSRF token strings.
 const XsrfTokenLength = 64
 
 // LoginHandler is a login handling system that presents a login page backed by

--- a/authentication/minsession.go
+++ b/authentication/minsession.go
@@ -42,6 +42,7 @@ func init() {
 	)
 }
 
+// UnmarshalJSON implements encoding/json.Unmarshaler.
 func (h *MinSessionHandler) UnmarshalJSON(data []byte) error {
 	log.Debug("Unmarshaling a MinSessionHandler")
 	var t struct {
@@ -78,6 +79,7 @@ func (handler *MinSessionHandler) assureTableInitialized() {
 	}
 }
 
+// GetSession generates a new session to track state with.
 func (handler *MinSessionHandler) GetSession() (Session, error) {
 	log.Info("minsessionhandler is generating a new session")
 	log.Debug(
@@ -178,6 +180,8 @@ type MinSession struct {
 	handler *MinSessionHandler
 }
 
+// GetValue looks up a value stored in the session for a given key. If the key
+// did not match an existing saved value, an error will be returned.
 func (sesh *MinSession) GetValue(key string) (interface{}, error) {
 	log.Debug(fmt.Sprintf("minsession requesting value for: %s", key))
 
@@ -189,12 +193,15 @@ func (sesh *MinSession) GetValue(key string) (interface{}, error) {
 	}
 }
 
+// GetValues retrieves all the key/value pairs associated with the session.
 func (sesh *MinSession) GetValues() map[string]interface{} {
 	log.Debug("minsession requesting all values")
 
 	return sesh.core.data
 }
 
+// SetValue saves a key/value pair into the session, possibly overwriting a
+// previously set value.
 func (sesh *MinSession) SetValue(key string, value interface{}) error {
 	log.Debug(fmt.Sprintf("minsession setting value for: %s", key))
 

--- a/authentication/minsession.go
+++ b/authentication/minsession.go
@@ -169,6 +169,8 @@ type minSessionCore struct {
 	data   map[string]interface{}
 }
 
+// MinSession represents a particular user session, and is intrinsically linked
+// with the MinSessionHandler that created it.
 type MinSession struct {
 	core    *minSessionCore
 	handler *MinSessionHandler

--- a/authentication/minsession.go
+++ b/authentication/minsession.go
@@ -61,6 +61,8 @@ func (h *MinSessionHandler) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+// NewMinSessionHandler creates an initialized session handler. Unfortunately a
+// nil MinSessionHandler does not currently provide the desired behavior.
 func NewMinSessionHandler(name, path, domain string) *MinSessionHandler {
 	return &MinSessionHandler{
 		name,

--- a/authentication/plugin.go
+++ b/authentication/plugin.go
@@ -1,3 +1,5 @@
 package authentication
 
+// LoadPlugin being called forces the package to be loaded in order to ensure
+// that the resource types are registered during the package's Init.
 func LoadPlugin() {}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -18,9 +18,9 @@ type dummyType struct{}
 func (s *dummyType) UnmarshalJSON(i []byte) error {
 	if string(i) == "\"error\"" {
 		return errors.New(`*dummyType.UnmarshalJSON("error")`)
-	} else {
-		return nil
 	}
+
+	return nil
 }
 func (s *dummyType) ServeHTTP(http.ResponseWriter, *http.Request) {
 }

--- a/config/doc.go
+++ b/config/doc.go
@@ -1,2 +1,2 @@
-// Configuration-related code for Pullcord
+// Package config contains configuration-related code for Pullcord
 package config

--- a/config/httpmultiserver.go
+++ b/config/httpmultiserver.go
@@ -10,9 +10,9 @@ import (
 	"github.com/proidiot/gone/log"
 )
 
-// HttpMultiServer implements the Pullcord server interface with an HTTP handler
+// HTTPMultiServer implements the Pullcord server interface with an HTTP handler
 // and multiple listeners.
-type HttpMultiServer struct {
+type HTTPMultiServer struct {
 	Listeners []net.Listener
 	Handler   http.Handler
 }
@@ -21,7 +21,7 @@ func init() {
 	e := RegisterResourceType(
 		"httpmultiserver",
 		func() json.Unmarshaler {
-			return new(HttpServer)
+			return new(HTTPServer)
 		},
 	)
 
@@ -30,7 +30,8 @@ func init() {
 	}
 }
 
-func (s *HttpMultiServer) UnmarshalJSON(d []byte) error {
+// UnmarshalJSON implements encoding/json.Unmarshaler.
+func (s *HTTPMultiServer) UnmarshalJSON(d []byte) error {
 	var t struct {
 		Listeners []Resource
 		Handler   Resource
@@ -60,7 +61,8 @@ func (s *HttpMultiServer) UnmarshalJSON(d []byte) error {
 	return nil
 }
 
-func (s *HttpMultiServer) Serve() error {
+// Serve implements .../pullcord/Server.
+func (s *HTTPMultiServer) Serve() error {
 	log.Debug(
 		fmt.Sprintf(
 			"Serving with listeners %#v and handler %#v",
@@ -96,7 +98,8 @@ func (s *HttpMultiServer) Serve() error {
 	return err
 }
 
-func (s *HttpMultiServer) Close() error {
+// Close implements .../pullcord/Server.
+func (s *HTTPMultiServer) Close() error {
 	var err error
 	for _, l := range s.Listeners {
 		log.Info(fmt.Sprintf("Closing server at %s...", l.Addr()))

--- a/config/httpserver.go
+++ b/config/httpserver.go
@@ -10,8 +10,8 @@ import (
 	"github.com/proidiot/gone/log"
 )
 
-// HttpServer implements the Pullcord server interface with an HTTP handler.
-type HttpServer struct {
+// HTTPServer implements the Pullcord server interface with an HTTP handler.
+type HTTPServer struct {
 	Listener net.Listener
 	Handler  http.Handler
 }
@@ -20,7 +20,7 @@ func init() {
 	e := RegisterResourceType(
 		"httpserver",
 		func() json.Unmarshaler {
-			return new(HttpServer)
+			return new(HTTPServer)
 		},
 	)
 
@@ -29,7 +29,8 @@ func init() {
 	}
 }
 
-func (s *HttpServer) UnmarshalJSON(d []byte) error {
+// UnmarshalJSON implements encoding/json.Unmarshaler.
+func (s *HTTPServer) UnmarshalJSON(d []byte) error {
 	var t struct {
 		Listener Resource
 		Handler  Resource
@@ -54,7 +55,8 @@ func (s *HttpServer) UnmarshalJSON(d []byte) error {
 	return nil
 }
 
-func (s *HttpServer) Serve() error {
+// Serve implements .../pullcord.Server.
+func (s *HTTPServer) Serve() error {
 	log.Debug(
 		fmt.Sprintf(
 			"Serving with listener %#v and handler %#v",
@@ -67,7 +69,8 @@ func (s *HttpServer) Serve() error {
 	return http.Serve(s.Listener, s.Handler)
 }
 
-func (s *HttpServer) Close() error {
+// Close implements .../pullcord.Server.
+func (s *HTTPServer) Close() error {
 	log.Info(fmt.Sprintf("Closing server at %s...", s.Listener.Addr()))
 	return s.Listener.Close()
 }

--- a/config/parser.go
+++ b/config/parser.go
@@ -5,16 +5,17 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/proidiot/gone/errors"
 	"github.com/proidiot/gone/log"
 
 	"github.com/stuphlabs/pullcord"
 )
 
+// Parser extracts configuration info from an io.Reader.
 type Parser struct {
 	Reader io.Reader
 }
 
+// Server extracts the .../pullcord.Server component from the config io.Reader.
 func (p Parser) Server() (pullcord.Server, error) {
 	registrationMutex.Lock()
 	defer registrationMutex.Unlock()
@@ -52,17 +53,16 @@ func (p Parser) Server() (pullcord.Server, error) {
 			registry[name] = r
 			if e := r.unmarshalByName(name); e != nil {
 				return nil, e
-			} else {
-				r.complete = true
-				log.Debug(
-					fmt.Sprintf(
-						"Saved resource to"+
-							" registry: %s: %#v",
-						name,
-						r.Unmarshaled,
-					),
-				)
 			}
+
+			r.complete = true
+			log.Debug(
+				fmt.Sprintf(
+					"Saved resource to registry: %s: %#v",
+					name,
+					r.Unmarshaled,
+				),
+			)
 		} else {
 			log.Debug(
 				fmt.Sprintf(
@@ -83,13 +83,10 @@ func (p Parser) Server() (pullcord.Server, error) {
 		return server, nil
 	}
 
-	//err := errors.New("The given server has the wrong type")
-	err := errors.New(
-		fmt.Sprintf(
-			"not a server: %s - %#v",
-			config.Server,
-			rserver.Unmarshaled,
-		),
+	err := fmt.Errorf(
+		"not a server: %s - %#v",
+		config.Server,
+		rserver.Unmarshaled,
 	)
 	log.Crit(err.Error())
 

--- a/config/typeregistry.go
+++ b/config/typeregistry.go
@@ -3,24 +3,24 @@ package config
 import (
 	"encoding/json"
 	"fmt"
-
-	"github.com/proidiot/gone/errors"
 )
 
 var typeRegistry = make(map[string]func() json.Unmarshaler)
 
+// RegisterResourceType is an infrastructure hack that allows new config
+// Resource types to be specified at run-time. It needs to be run before a
+// Parser is used, presumably in an Init function of the package of a config
+// plugin.
 func RegisterResourceType(
 	typeName string,
 	newFunc func() json.Unmarshaler,
 ) error {
 	_, present := typeRegistry[typeName]
 	if present || typeName == ReferenceResourceTypeName {
-		return errors.New(
-			fmt.Sprintf(
-				"More than one resource type has registerred"+
-					" the same name: %s",
-				typeName,
-			),
+		return fmt.Errorf(
+			"More than one resource type has registerred the same"+
+				" name: %s",
+			typeName,
 		)
 	}
 
@@ -28,6 +28,8 @@ func RegisterResourceType(
 	return nil
 }
 
+// MustRegisterResourceType is a convenience function around
+// RegisterResourceType that panics on error.
 func MustRegisterResourceType(
 	typeName string,
 	newFunc func() json.Unmarshaler,

--- a/config/util/configtest.go
+++ b/config/util/configtest.go
@@ -12,11 +12,15 @@ import (
 	"github.com/stuphlabs/pullcord/config"
 )
 
+// ConfigTestData contains the data for a specific test case for config
+// behavior, plus the corresponding explanation string.
 type ConfigTestData struct {
 	Data        string
 	Explanation string
 }
 
+// ConfigTest represents an entire suite of tests for config behavior of a
+// particular resource type.
 type ConfigTest struct {
 	ResourceType     string
 	IsValid          func(json.Unmarshaler) error
@@ -26,6 +30,7 @@ type ConfigTest struct {
 	ListenerTest     bool
 }
 
+// Run executes the suite of config behavior tests.
 func (c *ConfigTest) Run(t *testing.T) {
 	isValidWasRun := false
 
@@ -34,9 +39,8 @@ func (c *ConfigTest) Run(t *testing.T) {
 			isValidWasRun = true
 			if c.IsValid != nil {
 				return c.IsValid(i)
-			} else {
-				return nil
 			}
+			return nil
 		},
 	)
 	assert.NoError(
@@ -245,41 +249,40 @@ func constructConfigReader(
 				data,
 			),
 		)
-	} else {
-		return strings.NewReader(
-			fmt.Sprintf(
-				`{
-					"resources": {
-						"handler": {
+	}
+	return strings.NewReader(
+		fmt.Sprintf(
+			`{
+				"resources": {
+					"handler": {
+						"type": "%s",
+						"data": {
 							"type": "%s",
-							"data": {
-								"type": "%s",
-								"data": %s
-							}
-						},
-						"listener": {
-							"type": "testlistener",
-							"data": null
+							"data": %s
 						}
 					},
-					"server": {
-						"type": "httpserver",
-						"data": {
-							"handler": {
-								"type": "ref",
-								"data": "handler"
-							},
-							"listener": {
-								"type": "ref",
-								"data": "listener"
-							}
+					"listener": {
+						"type": "testlistener",
+						"data": null
+					}
+				},
+				"server": {
+					"type": "httpserver",
+					"data": {
+						"handler": {
+							"type": "ref",
+							"data": "handler"
+						},
+						"listener": {
+							"type": "ref",
+							"data": "listener"
 						}
 					}
-				}`,
-				validatorName,
-				resourceType,
-				data,
-			),
-		)
-	}
+				}
+			}`,
+			validatorName,
+			resourceType,
+			data,
+		),
+	)
 }

--- a/config/util/handler.go
+++ b/config/util/handler.go
@@ -7,6 +7,8 @@ import (
 	"github.com/stuphlabs/pullcord/config"
 )
 
+// TestHandler is a dummy net/http.Handler implementation that can be used for
+// testing.
 type TestHandler struct {
 }
 
@@ -23,9 +25,11 @@ func init() {
 	}
 }
 
+// UnmarshalJSON implements encoding/json.Unmarshaler.
 func (t *TestHandler) UnmarshalJSON([]byte) error {
 	return nil
 }
 
+// ServeHTTP implements net/http.Handler.
 func (t *TestHandler) ServeHTTP(http.ResponseWriter, *http.Request) {
 }

--- a/config/util/listener.go
+++ b/config/util/listener.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stuphlabs/pullcord/config"
 )
 
+// TestListener is a dummy net.Listener that can be used for testing.
 type TestListener struct {
 }
 
@@ -24,22 +25,26 @@ func init() {
 	}
 }
 
+// UnmarshalJSON implements encoding/json.Unmarshaler.
 func (t *TestListener) UnmarshalJSON([]byte) error {
 	return nil
 }
 
+// Accept implements net.Listener.
 func (t *TestListener) Accept() (net.Conn, error) {
 	return nil, errors.New(
-		"TestListener is not intended to be used as a real listener.",
+		"TestListener is not intended to be used as a real listener",
 	)
 }
 
+// Close implements net.Listener.
 func (t *TestListener) Close() error {
 	return errors.New(
-		"TestListener is not intended to be used as a real listener.",
+		"TestListener is not intended to be used as a real listener",
 	)
 }
 
+// Addr implements net.Listener.
 func (t *TestListener) Addr() net.Addr {
 	return nil
 }

--- a/config/util/validator.go
+++ b/config/util/validator.go
@@ -23,10 +23,10 @@ func (v *validation) UnmarshalJSON(input []byte) error {
 	dec := json.NewDecoder(bytes.NewReader(input))
 	if e := dec.Decode(&r); e != nil {
 		return e
-	} else {
-		v.unmarshaled = r.Unmarshaled
-		return v.validate(v.unmarshaled)
 	}
+
+	v.unmarshaled = r.Unmarshaled
+	return v.validate(v.unmarshaled)
 }
 
 var responseString = `<!DOCTYPE html>
@@ -75,6 +75,9 @@ func (v *validation) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	)
 }
 
+// GenerateValidator registers a specialty resource type that can be used to
+// test config behavior of another resource type as part of resource
+// unmarshaling.
 func GenerateValidator(
 	validate func(json.Unmarshaler) error,
 ) (string, error) {

--- a/doc.go
+++ b/doc.go
@@ -1,3 +1,3 @@
-// Pullcord is a kind of reverse proxy that manages the services it proxies to
-// so that those servers can be shut down when not in use.
+// Package pullcord is a kind of reverse proxy that manages the services it
+// proxies to so that those servers can be shut down when not in use.
 package pullcord

--- a/monitor/doc.go
+++ b/monitor/doc.go
@@ -1,2 +1,2 @@
-// Remote service monitor code for Pullcord
+// Package monitor contains mechanisms for monitorring remote services
 package monitor

--- a/monitor/minmonitor.go
+++ b/monitor/minmonitor.go
@@ -118,6 +118,7 @@ func (s *MinMonitorredService) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+// NewMinMonitorredService creates an initialized MinMonitorredService.
 func NewMinMonitorredService(
 	u *url.URL,
 	gracePeriod time.Duration,

--- a/monitor/minmonitor.go
+++ b/monitor/minmonitor.go
@@ -30,7 +30,7 @@ const UnknownServiceError = errors.New(
 	"No service has been registered with the requested name",
 )
 
-// MonitorredService holds the information for a single service definition.
+// MinMonitorredService holds the information for a single service definition.
 type MinMonitorredService struct {
 	URL         *url.URL
 	GracePeriod time.Duration
@@ -386,11 +386,11 @@ func (svc *MinMonitorredService) SetStatusUp() error {
 	return nil
 }
 
-// NewMonitorFilter produces a Falcore RequestFilter for a given named service.
-// This filter will forward to the service if it is up, otherwise it will
-// display an error page to the requester. There are also optional triggers
-// which would be run if the service is down (presumably to bring it up), or if
-// the service is already up, or in either case, respectively.
+// NewMinMonitorFilter produces an http.Handler for a given named service. This
+// handler will forward to the service if it is up, otherwise it will display an
+// error page to the requester. There are also optional triggers which would be
+// run if the service is down (presumably to bring it up), or if the service is
+// already up, or in either case, respectively.
 func (monitor *MinMonitor) NewMinMonitorFilter(
 	name string,
 ) (http.Handler, error) {

--- a/monitor/plugin.go
+++ b/monitor/plugin.go
@@ -1,3 +1,5 @@
 package monitor
 
+// LoadPlugin being called forces the package to be loaded in order to ensure
+// that the resource types are registered during the package's Init.
 func LoadPlugin() {}

--- a/net/acme.go
+++ b/net/acme.go
@@ -30,6 +30,7 @@ type AcmeConfig struct {
 	lsr       net.Listener
 }
 
+// UnmarshalJSON implements encoding/json.Unmarshaler.
 func (a *AcmeConfig) UnmarshalJSON(d []byte) error {
 	var t struct {
 		AcceptTOS bool
@@ -53,6 +54,9 @@ func (a *AcmeConfig) UnmarshalJSON(d []byte) error {
 	return nil
 }
 
+// GetManager retrieves an x/crypto/acme/autocert.Manager with the previously
+// defined config values. Subsequent calls return the same autocert.Manager
+// object which has been preserved.
 func (a *AcmeConfig) GetManager() (*autocert.Manager, error) {
 	if a.mgr != nil {
 		return a.mgr, nil
@@ -73,6 +77,9 @@ func (a *AcmeConfig) GetManager() (*autocert.Manager, error) {
 	return a.mgr, nil
 }
 
+// Listener retrieves a net.Listener from the autocert.Manager given by
+// AcmeConfig.GetManager. Subsequent calls return the same net.Listener object
+// which has been preserved.
 func (a *AcmeConfig) Listener() (net.Listener, error) {
 	if a.lsr != nil {
 		return a.lsr, nil
@@ -88,6 +95,9 @@ func (a *AcmeConfig) Listener() (net.Listener, error) {
 	return a.lsr, nil
 }
 
+// GetCertificate implements TlsCertificateGetter so that this object can be
+// used as part of another net.Listener in case behavior other than what is
+// provided by AcmeConfig.Listener is desired.
 func (a *AcmeConfig) GetCertificate(
 	hello *tls.ClientHelloInfo,
 ) (*tls.Certificate, error) {
@@ -99,6 +109,7 @@ func (a *AcmeConfig) GetCertificate(
 	return mgr.GetCertificate(hello)
 }
 
+// Accept implements net.Listener.
 func (a *AcmeConfig) Accept() (net.Conn, error) {
 	lsr, e := a.Listener()
 	if e != nil {
@@ -108,6 +119,7 @@ func (a *AcmeConfig) Accept() (net.Conn, error) {
 	return lsr.Accept()
 }
 
+// Close implements net.Listener.
 func (a *AcmeConfig) Close() error {
 	lsr, e := a.Listener()
 	if e != nil {
@@ -117,6 +129,7 @@ func (a *AcmeConfig) Close() error {
 	return lsr.Close()
 }
 
+// Addr implements net.Listener.
 func (a *AcmeConfig) Addr() net.Addr {
 	lsr, e := a.Listener()
 	if e != nil {

--- a/net/acme.go
+++ b/net/acme.go
@@ -20,6 +20,9 @@ func init() {
 	)
 }
 
+// AcmeConfig represents the configuration details to be used with
+// x/crypto/acme/autocert. It can also act as a wrapper around the
+// autocert.Manager and net.Listener it generates.
 type AcmeConfig struct {
 	AcceptTOS bool
 	Domains   []string

--- a/net/basic.go
+++ b/net/basic.go
@@ -26,6 +26,7 @@ func init() {
 	}
 }
 
+// UnmarshalJSON implements encoding/json.Unmarshaler.
 func (b *BasicListener) UnmarshalJSON(d []byte) error {
 	var t struct {
 		Proto string
@@ -44,14 +45,17 @@ func (b *BasicListener) UnmarshalJSON(d []byte) error {
 	}
 }
 
+// Accept implements net.Listener.
 func (b *BasicListener) Accept() (net.Conn, error) {
 	return b.Listener.Accept()
 }
 
+// Close implements net.Listener.
 func (b *BasicListener) Close() error {
 	return b.Listener.Close()
 }
 
+// Addr implements net.Listener.
 func (b *BasicListener) Addr() net.Addr {
 	return b.Listener.Addr()
 }

--- a/net/basic.go
+++ b/net/basic.go
@@ -7,6 +7,8 @@ import (
 	"github.com/stuphlabs/pullcord/config"
 )
 
+// BasicListener augments the functionality of a net.Listen call by wrapping it
+// in an encoding/json.Unmarshaler (and thereby making it be configurable).
 type BasicListener struct {
 	Listener net.Listener
 }

--- a/net/basictls.go
+++ b/net/basictls.go
@@ -42,6 +42,7 @@ func init() {
 	}
 }
 
+// UnmarshalJSON implements encoding/json.Unmarshaler.
 func (b *BasicTlsListener) UnmarshalJSON(d []byte) error {
 	var t struct {
 		Listener   config.Resource
@@ -92,16 +93,19 @@ func (b *BasicTlsListener) assureActualListenerCreated() {
 	}
 }
 
+// Accept implements net.Listener.
 func (b *BasicTlsListener) Accept() (net.Conn, error) {
 	b.assureActualListenerCreated()
 	return b.actualListener.Accept()
 }
 
+// Close implements net.Listener.
 func (b *BasicTlsListener) Close() error {
 	b.assureActualListenerCreated()
 	return b.actualListener.Close()
 }
 
+// Addr implements net.Listener.
 func (b *BasicTlsListener) Addr() net.Addr {
 	b.assureActualListenerCreated()
 	return b.actualListener.Addr()

--- a/net/basictls.go
+++ b/net/basictls.go
@@ -12,10 +12,17 @@ import (
 	"github.com/stuphlabs/pullcord/config"
 )
 
+// TlsCertificateGetter provides a mechanism by which the assignment of the
+// crypto/tls.Config.GetCertificate method can be abstracted independently from
+// other aspects of the creation of the net.Listener returned from a call to
+// crypto/tls.NewListener.
 type TlsCertificateGetter interface {
 	GetCertificate(*tls.ClientHelloInfo) (*tls.Certificate, error)
 }
 
+// BasicTlsListener combines the certificate retrieval process abstracted by a
+// TlsCertificateGetter with a supplied net.Listener to give a simple
+// configurable wrapper around a call to crypto/tls.NewListener.
 type BasicTlsListener struct {
 	Listener       net.Listener
 	CertGetter     TlsCertificateGetter

--- a/net/pem.go
+++ b/net/pem.go
@@ -20,6 +20,8 @@ func init() {
 	}
 }
 
+// PemConfig implements a TlsCertificateGetter using a single PEM encoded key
+// and certificate pair.
 type PemConfig struct {
 	Cert []byte
 	Key  []byte

--- a/net/pem.go
+++ b/net/pem.go
@@ -27,6 +27,7 @@ type PemConfig struct {
 	Key  []byte
 }
 
+// UnmarshalJSON implements encoding/json.Unmarshaler.
 func (p *PemConfig) UnmarshalJSON(d []byte) error {
 	var t struct {
 		Cert string
@@ -43,6 +44,7 @@ func (p *PemConfig) UnmarshalJSON(d []byte) error {
 	return nil
 }
 
+// GetCertificate implements TlsCertificateGetter.
 func (p *PemConfig) GetCertificate(
 	*tls.ClientHelloInfo,
 ) (*tls.Certificate, error) {

--- a/net/plugin.go
+++ b/net/plugin.go
@@ -1,3 +1,5 @@
 package net
 
+// LoadPlugin being called forces the package to be loaded in order to ensure
+// that the resource types are registered during the package's Init.
 func LoadPlugin() {}

--- a/proxy/doc.go
+++ b/proxy/doc.go
@@ -1,2 +1,2 @@
-// Remote service proxying code for Pullcord
+// Package proxy contains a mechanism for proxying requests to a remote service
 package proxy

--- a/proxy/passthru.go
+++ b/proxy/passthru.go
@@ -25,6 +25,8 @@ func init() {
 	)
 }
 
+// NewPassthruFilter creates a PassthruFilter using a single host reverse proxy
+// pointing at the given url.URL.
 func NewPassthruFilter(u *url.URL) *PassthruFilter {
 	return (*PassthruFilter)(httputil.NewSingleHostReverseProxy(u))
 }

--- a/proxy/passthru.go
+++ b/proxy/passthru.go
@@ -31,6 +31,7 @@ func NewPassthruFilter(u *url.URL) *PassthruFilter {
 	return (*PassthruFilter)(httputil.NewSingleHostReverseProxy(u))
 }
 
+// UnmarshalJSON implements encoding/json.Unmarshaler.
 func (f *PassthruFilter) UnmarshalJSON(input []byte) error {
 	var t struct {
 		Host string

--- a/proxy/passthru.go
+++ b/proxy/passthru.go
@@ -11,6 +11,9 @@ import (
 	"github.com/stuphlabs/pullcord/config"
 )
 
+// PassthruFilter provides a mechanism by which a net/http/httputil.ReverseProxy
+// can be configured. This reverse proxy allows requests received by Pullcord to
+// be sent to a remote service.
 type PassthruFilter httputil.ReverseProxy
 
 func init() {

--- a/proxy/plugin.go
+++ b/proxy/plugin.go
@@ -1,3 +1,5 @@
 package proxy
 
+// LoadPlugin being called forces the package to be loaded in order to ensure
+// that the resource types are registered during the package's Init.
 func LoadPlugin() {}

--- a/trigger/compound.go
+++ b/trigger/compound.go
@@ -57,8 +57,8 @@ func (c *CompoundTrigger) UnmarshalJSON(input []byte) error {
 	}
 }
 
-// TriggerString implements the required string-based triggering function to
-// make CompoundTrigger a valid TriggerHandler implementation.
+// Trigger executes all the child triggers, exiting immediately after a single
+// failure.
 func (ct *CompoundTrigger) Trigger() error {
 	for _, t := range ct.Triggers {
 		if err := t.Trigger(); err != nil {

--- a/trigger/compound.go
+++ b/trigger/compound.go
@@ -25,6 +25,7 @@ func init() {
 	)
 }
 
+// UnmarshalJSON implements encoding/json.Unmarshaler.
 func (c *CompoundTrigger) UnmarshalJSON(input []byte) error {
 	var t struct {
 		Triggers []config.Resource

--- a/trigger/delay.go
+++ b/trigger/delay.go
@@ -106,10 +106,10 @@ func delaytrigger(
 	}
 }
 
-// TriggerString implements the required string-based triggering function to
-// make DelayTrigger a valid TriggerHandler implementation. This function
-// effectively cancels any previous trigger and replaces it with a call using
-// only this most recent string value.
+// Trigger sets or resets the delay after which it will execute the child
+// trigger. The child trigger will be executed no sooner than the delay time
+// after any particular call, but subsequent calls may extend that time out
+// further (possibly indefinitely).
 func (dt *DelayTrigger) Trigger() error {
 	if dt.c == nil {
 		fc := make(chan interface{})

--- a/trigger/delay.go
+++ b/trigger/delay.go
@@ -29,6 +29,7 @@ func init() {
 	)
 }
 
+// UnmarshalJSON implements encoding/json.Unmarshaler.
 func (d *DelayTrigger) UnmarshalJSON(input []byte) error {
 	var t struct {
 		DelayedTrigger config.Resource

--- a/trigger/delay.go
+++ b/trigger/delay.go
@@ -63,6 +63,8 @@ func (d *DelayTrigger) UnmarshalJSON(input []byte) error {
 	return nil
 }
 
+// NewDelayTrigger initializes a DelayTrigger. It might not be strictly
+// necessary anymore.
 func NewDelayTrigger(
 	delayedTrigger TriggerHandler,
 	delay time.Duration,

--- a/trigger/doc.go
+++ b/trigger/doc.go
@@ -1,2 +1,2 @@
-// Remote service controlling code for Pullcord
+// Package trigger provides tools for remotely controlling service lifecycle
 package trigger

--- a/trigger/plugin.go
+++ b/trigger/plugin.go
@@ -1,3 +1,5 @@
 package trigger
 
+// LoadPlugin being called forces the package to be loaded in order to ensure
+// that the resource types are registered during the package's Init.
 func LoadPlugin() {}

--- a/trigger/ratelimit.go
+++ b/trigger/ratelimit.go
@@ -72,6 +72,8 @@ func (r *RateLimitTrigger) UnmarshalJSON(input []byte) error {
 	return nil
 }
 
+// NewRateLimitTrigger initializes a RateLimitTrigger. It may no longer be
+// strictly necessary.
 func NewRateLimitTrigger(
 	guardedTrigger TriggerHandler,
 	maxAllowed uint,

--- a/trigger/ratelimit.go
+++ b/trigger/ratelimit.go
@@ -35,6 +35,7 @@ func init() {
 	)
 }
 
+// UnmarshalJSON implements encoding/json.Unmarshaler.
 func (r *RateLimitTrigger) UnmarshalJSON(input []byte) error {
 	var t struct {
 		GuardedTrigger config.Resource

--- a/trigger/ratelimit.go
+++ b/trigger/ratelimit.go
@@ -85,10 +85,10 @@ func NewRateLimitTrigger(
 	}
 }
 
-// TriggerString implements the required string-based triggering function to
-// make RateLimitTrigger a valid TriggerHandler implementation. If the rate
-// limit is exceeded, RateLimitExceededError will be returned, and the guarded
-// trigger will not be called.
+// Trigger executes its guarded trigger if and only if it has not be called more
+// than the allowed number of times within the specified rolling window of time.
+// If the rate limit is exceeded, RateLimitExceededError will be returned, and
+// the guarded trigger will not be called.
 func (rlt *RateLimitTrigger) Trigger() error {
 	now := time.Now()
 

--- a/trigger/shelltrigger.go
+++ b/trigger/shelltrigger.go
@@ -28,6 +28,7 @@ func init() {
 	)
 }
 
+// UnmarshalJSON implements encoding/json.Unmarshaler.
 func (s *ShellTriggerHandler) UnmarshalJSON(input []byte) error {
 	// It shouldn't habe been necessary to do this, but by giving a
 	// defnition of how to unmarshal a pointer-to ShellTriggerHandler

--- a/trigger/shelltrigger.go
+++ b/trigger/shelltrigger.go
@@ -50,10 +50,8 @@ func (s *ShellTriggerHandler) UnmarshalJSON(input []byte) error {
 	return nil
 }
 
-// TriggerString for the ShellTriggerHandler is an implementation of the
-// TriggerString function required by all TriggerHandler instances.
-//
-// In this case, the message will be passed to the command via stdin.
+// Trigger will execute the given command with the given args using the system
+// shell.
 func (handler *ShellTriggerHandler) Trigger() (err error) {
 	log.Debug("shelltrigger running trigger")
 	cmd := exec.Command(handler.Command, handler.Args...)

--- a/trigger/sqstrigger.go
+++ b/trigger/sqstrigger.go
@@ -5,6 +5,8 @@ import (
 	// "github.com/stuphlabs/pullcord"
 )
 
+// SqsTriggerHandler is a work-in-progress that is intended to eventually send
+// SQS messages as the result of a triggering event.
 type SqsTriggerHandler struct {
 	url string
 }

--- a/trigger/sqstrigger.go
+++ b/trigger/sqstrigger.go
@@ -11,6 +11,8 @@ type SqsTriggerHandler struct {
 	url string
 }
 
+// Trigger implemented TriggerHandler and actually performs the encapsulated
+// behavior.
 func (handler *SqsTriggerHandler) Trigger(message string) (err error) {
 	return errors.New("Not yet implemented")
 }

--- a/trigger/sqstrigger.go
+++ b/trigger/sqstrigger.go
@@ -15,6 +15,8 @@ func (handler *SqsTriggerHandler) Trigger(message string) (err error) {
 	return errors.New("Not yet implemented")
 }
 
+// NewSqsTriggerHandler initializes a SqsTriggerHandler. It may no longer be
+// strictly necessary.
 func NewSqsTriggerHandler(url string) *SqsTriggerHandler {
 	var handler SqsTriggerHandler
 	handler.url = url

--- a/util/doc.go
+++ b/util/doc.go
@@ -1,2 +1,3 @@
-// Basic utilities which come in handy for constructing real pullcord installs.
+// Package util provides basic utilities which come in handy for constructing
+// real pullcord installs.
 package util

--- a/util/landing.go
+++ b/util/landing.go
@@ -22,6 +22,7 @@ func init() {
 	)
 }
 
+// UnmarshalJSON implements encoding/json.Unmarshaler.
 func (l *LandingHandler) UnmarshalJSON(data []byte) error {
 	return nil
 }

--- a/util/landing.go
+++ b/util/landing.go
@@ -8,6 +8,8 @@ import (
 	"github.com/stuphlabs/pullcord/config"
 )
 
+// LandingHandler is a net/http.Handler that acts as a default landing page for
+// a (presumably not-yet-production) Pullcord instance.
 type LandingHandler struct {
 }
 

--- a/util/path_route_adapter.go
+++ b/util/path_route_adapter.go
@@ -26,6 +26,7 @@ func init() {
 	)
 }
 
+// UnmarshalJSON implements encoding/json.Unmarshaler.
 func (r *ExactPathRouter) UnmarshalJSON(input []byte) error {
 	var t struct {
 		Routes  map[string]*config.Resource

--- a/util/path_route_adapter.go
+++ b/util/path_route_adapter.go
@@ -10,6 +10,8 @@ import (
 	"github.com/stuphlabs/pullcord/config"
 )
 
+// ExactPathRouter is a net/http.Handler that routes to other handlers based on
+// an exactly matching path, or an optional default handler.
 type ExactPathRouter struct {
 	Routes  map[string]http.Handler
 	Default http.Handler

--- a/util/plugin.go
+++ b/util/plugin.go
@@ -1,3 +1,5 @@
 package util
 
+// LoadPlugin being called forces the package to be loaded in order to ensure
+// that the resource types are registered during the package's Init.
 func LoadPlugin() {}

--- a/util/standard_responses.go
+++ b/util/standard_responses.go
@@ -31,6 +31,7 @@ func init() {
 	)
 }
 
+// UnmarshalJSON implements encoding/json.Unmarshaler.
 func (s *StandardResponse) UnmarshalJSON(data []byte) error {
 	var t int
 	if e := json.Unmarshal(data, &t); e != nil {

--- a/util/standard_responses.go
+++ b/util/standard_responses.go
@@ -12,6 +12,8 @@ import (
 
 type StandardResponse int
 
+// MinimumStandardResponse is the lower limit of acceptable HTTP response codes
+// for which a StandardResponse can be created.
 const MinimumStandardResponse = 100
 
 func init() {
@@ -46,8 +48,11 @@ func (s *StandardResponse) UnmarshalJSON(data []byte) error {
 }
 
 const (
+	// NotFound is a canned StandardResponse for an HTTP 404
 	NotFound            = StandardResponse(404)
+	// InternalServerError is a canned StandardResponse for an HTTP 500
 	InternalServerError = StandardResponse(500)
+	// NotImplemented is a canned StandardResponse for an HTTP 501
 	NotImplemented      = StandardResponse(501)
 )
 

--- a/util/standard_responses.go
+++ b/util/standard_responses.go
@@ -56,11 +56,11 @@ func (s *StandardResponse) UnmarshalJSON(data []byte) error {
 
 const (
 	// NotFound is a canned StandardResponse for an HTTP 404
-	NotFound            = StandardResponse(404)
+	NotFound = StandardResponse(404)
 	// InternalServerError is a canned StandardResponse for an HTTP 500
 	InternalServerError = StandardResponse(500)
 	// NotImplemented is a canned StandardResponse for an HTTP 501
-	NotImplemented      = StandardResponse(501)
+	NotImplemented = StandardResponse(501)
 )
 
 var responseTitle = map[StandardResponse]string{

--- a/util/standard_responses.go
+++ b/util/standard_responses.go
@@ -10,6 +10,12 @@ import (
 	"github.com/stuphlabs/pullcord/config"
 )
 
+// StandardResponse implements a net/http.Handler that gives a canned version of
+// the appropriate response for some HTTP code. For example, rather than going
+// to the trouble of creating another net/http.Handler to deal with a request
+// for a non-existant page, you could instead cast the literal integer 404 as a
+// StandardResponse and the appropriate action will be taken (so long as the
+// canned response this implementation provides will suffice).
 type StandardResponse int
 
 // MinimumStandardResponse is the lower limit of acceptable HTTP response codes


### PR DESCRIPTION
Adds the remaining missing doc blocks of exported symbols. As with the existing doc blocks, the relative quality of this documentation varies pretty wildly. This should be enough to fulfill both the letter and the spirit of the warnings from `golint`.

Also, some other fixes for `golint` related issues were included for `config` and `config/util` since those changes were made before #142 was broken down better, and it would be too much of a pain to extract these changes elsewhere now.