### PR TITLE
Closes #159 - Explicitly removing sudo access.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: go
-
+sudo: false
 before_install:
         - .travis/gofmt.sh
         - .travis/goimports.sh


### PR DESCRIPTION
At one point this was necessary in order to use the `sudo`-less Docker-based builds were run at Travis. These also had the advantage of being preferentially scheduled, which could mean a much lower turn-around time.