### PR TITLE
Closes #172 - Explicitly labelling the config.Parser.Reader

### DIFF
--- a/cmd/pullcord/main.go
+++ b/cmd/pullcord/main.go
@@ -161,7 +161,7 @@ func main() {
 		}
 	}
 
-	cfgParser := config.Parser{cfgReader}
+	cfgParser := config.Parser{Reader: cfgReader}
 	server, err := cfgParser.Server()
 	if err != nil {
 		log.Debug(err)

--- a/config/util/configtest.go
+++ b/config/util/configtest.go
@@ -61,7 +61,7 @@ func (c *ConfigTest) Run(t *testing.T) {
 		isValidWasRun = false
 
 		parser := config.Parser{
-			constructConfigReader(
+			Reader: constructConfigReader(
 				c.ListenerTest,
 				validatorName,
 				c.ResourceType,
@@ -111,7 +111,7 @@ func (c *ConfigTest) Run(t *testing.T) {
 		isValidWasRun = false
 
 		parser := config.Parser{
-			constructConfigReader(
+			Reader: constructConfigReader(
 				c.ListenerTest,
 				validatorName,
 				c.ResourceType,
@@ -161,7 +161,7 @@ func (c *ConfigTest) Run(t *testing.T) {
 		isValidWasRun = false
 
 		parser := config.Parser{
-			constructConfigReader(
+			Reader: constructConfigReader(
 				c.ListenerTest,
 				validatorName,
 				c.ResourceType,


### PR DESCRIPTION
Go vet didn't like that the `config.Parser.Reader` wasn't being explicitly identified within an inline `config.Parser` definition.