### PR TITLE
Closes #187 - Udating example/login.json

### DIFF
--- a/example/login.json
+++ b/example/login.json
@@ -27,7 +27,7 @@
 					"data": "pwdmgr"
 				},
 				"downstream": {
-					"type": "landingfilter",
+					"type": "landinghandler",
 					"data": {}
 				}
 			}
@@ -60,10 +60,6 @@
 				}
 			}
 		},
-		"handler": {
-			"type": "ref",
-			"data": "ckefltr"
-		},
 		"listener": {
 			"type": "basiclistener",
 			"data": {
@@ -72,6 +68,17 @@
 			}
 		}
 	},
-	"listener": "listener",
-	"handler": "handler"
+	"server": {
+		"type": "httpserver",
+		"data": {
+			"listener": {
+				"type": "ref",
+				"data": "listener"
+			},
+			"handler": {
+				"type": "ref",
+				"data": "ckefltr"
+			}
+		}
+	}
 }


### PR DESCRIPTION
The `example/login.json` was pretty out of date, but this should fix it.