### PR TITLE
Closes #195 - Switching to JIT passthru creation.

### DIFF
--- a/monitor/minmonitor.go
+++ b/monitor/minmonitor.go
@@ -129,14 +129,14 @@ func NewMinMonitorredService(
 	always trigger.Triggerrer,
 ) (service *MinMonitorredService, err error) {
 	result := MinMonitorredService{
-		u,
-		gracePeriod,
-		onDown,
-		onUp,
-		always,
-		time.Time{},
-		false,
-		proxy.NewPassthruFilter(u),
+		URL: u,
+		GracePeriod: gracePeriod,
+		OnDown: onDown,
+		OnUp: onUp,
+		Always: always,
+		lastChecked: time.Time{},
+		up: false,
+		passthru: nil,
 	}
 
 	return &result, nil
@@ -558,6 +558,16 @@ func (s *MinMonitorredService) ServeHTTP(
 				return
 			}
 			_ = log.Debug("minmonitor completed up trigger")
+		}
+
+		if s.passthru == nil {
+			_ = log.Debug(
+				"minmonitor filter passthru creation started",
+			)
+			s.passthru = proxy.NewPassthruFilter(s.URL)
+			_ = log.Debug(
+				"minmonitor filter passthru creation completed",
+			)
 		}
 
 		_ = log.Debug("minmonitor filter passthru starting")

--- a/monitor/minmonitor.go
+++ b/monitor/minmonitor.go
@@ -129,14 +129,14 @@ func NewMinMonitorredService(
 	always trigger.Triggerrer,
 ) (service *MinMonitorredService, err error) {
 	result := MinMonitorredService{
-		URL: u,
+		URL:         u,
 		GracePeriod: gracePeriod,
-		OnDown: onDown,
-		OnUp: onUp,
-		Always: always,
+		OnDown:      onDown,
+		OnUp:        onUp,
+		Always:      always,
 		lastChecked: time.Time{},
-		up: false,
-		passthru: nil,
+		up:          false,
+		passthru:    nil,
 	}
 
 	return &result, nil


### PR DESCRIPTION
Switching minmonitor to use just-in-time passthru creation. Previously there was passthru creation in the optional minmonitor constructor, but no passthru creation was occurring for the more common situation of JSON deserialization during the config process.