### PR TITLE
Closes #200 - Changes golang build cache location

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -15,6 +15,7 @@ GO := ${DOCKER} \
 	-v $${PWD}/:/go/src/${ROOTPKG}/ \
 	-w /go/src/${ROOTPKG}/ \
 	-u `id -u` \
+	-e XDG_CACHE_HOME='/tmp/.cache' \
 	_DOCKER_GOLANG_IMG_ \
 	_GO_CMD_
 ],[


### PR DESCRIPTION
When using the golang Docker image as non-root, you don't have permissions to
create `/.cache/go-build` within the container. Presumably golang should check
have a more sane default build cache in such a situation. It sounds as though
this is indeed the behavior that has been pulled into upstream. However, it is
not clear why the behavior isn't fixed with current golang Docker image.
[Upstream bug](https://github.com/docker-library/golang/issues/225)